### PR TITLE
try to allow dependabot prs to run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
     branches: [ "main" ]
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-  pull_request:
+  pull_request_target:
     branches: [ "main" ]
 jobs:
   test-components:
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           fetch-tags: true
       - id: "authenticate"


### PR DESCRIPTION
was trying to make the simplest adjustment defined here: https://github.com/dependabot/dependabot-core/issues/3253

but if i understood these correctly, the change disables the old pipeline and creates a new type which would only be picked up once we merge this to `main`.

once we merge this, i think we also need to cancel the other two PRs and have dependabot re-create new ones.