### PR TITLE
generate service ids from method names

### DIFF
--- a/rats-apps/src/python/rats/apps/__init__.py
+++ b/rats-apps/src/python/rats/apps/__init__.py
@@ -7,6 +7,7 @@ domain.
 
 from ._annotations import (
     AnnotatedContainer,
+    autoid_service,
     config,
     container,
     fallback_config,
@@ -40,6 +41,7 @@ __all__ = [
     "group",
     "service",
     "method_service_id",
+    "autoid_service",
     "CompositeContainer",
     "PluginContainers",
 ]

--- a/rats-apps/src/python/rats/apps/__init__.py
+++ b/rats-apps/src/python/rats/apps/__init__.py
@@ -13,11 +13,14 @@ from ._annotations import (
     fallback_group,
     fallback_service,
     group,
+    method_service_id,
     service,
 )
+from ._composite_container import CompositeContainer
 from ._container import Container, DuplicateServiceError, ServiceNotFoundError
 from ._ids import ConfigId, ServiceId
 from ._namespaces import ProviderNamespaces
+from ._plugin_container import PluginContainers
 from ._scoping import autoscope
 
 __all__ = [
@@ -36,4 +39,7 @@ __all__ = [
     "fallback_service",
     "group",
     "service",
+    "method_service_id",
+    "CompositeContainer",
+    "PluginContainers",
 ]

--- a/rats-apps/src/python/rats/apps/_annotations.py
+++ b/rats-apps/src/python/rats/apps/_annotations.py
@@ -160,13 +160,16 @@ def method_service_id(method: Callable[..., T_ServiceType]) -> ServiceId[T_Servi
 def fn_annotation_decorator(
     namespace: str,
     service_id: ServiceId[T_ServiceType] | None,
-) -> Callable[..., Callable[..., T_ServiceType]]:
+) -> Callable[[Callable[P, T_ServiceType]], Callable[P, T_ServiceType]]:
     def wrapper(
-        fn: Callable[..., T_ServiceType],
-    ) -> Callable[..., T_ServiceType]:
+        fn: Callable[P, T_ServiceType],
+    ) -> Callable[P, T_ServiceType]:
         _service_id = service_id or method_service_id(fn)
         _add_annotation(namespace, fn, _service_id)
-        return cache(fn)
+        cached_fn = cache(fn)
+        # The static type of cached_fn should be correct, but it does not maintain the param-spec,
+        # so we need to cast.
+        return cast(Callable[P, T_ServiceType], cached_fn)
 
     return wrapper
 

--- a/rats-apps/src/python/rats/apps/_annotations.py
+++ b/rats-apps/src/python/rats/apps/_annotations.py
@@ -8,6 +8,7 @@ from typing_extensions import NamedTuple
 from ._container import Container
 from ._ids import ConfigId, ServiceId, T_ConfigType, T_ServiceType
 from ._namespaces import ProviderNamespaces
+from ._scoping import scope_service_name
 
 DEFAULT_CONTAINER_GROUP = ServiceId[Container]("__default__")
 
@@ -139,7 +140,9 @@ def _get_method_service_id_name(method: Callable[..., Any]) -> str:
     if existing_names:
         return existing_names[0]
     else:
-        service_name = f"__rats_auto_method_service_id_:{method.__module__}.{method.__qualname__}"
+        module_name = method.__module__
+        class_name, method_name = method.__qualname__.rsplit(".", 1)
+        service_name = scope_service_name(module_name, class_name, method_name)
         return service_name
 
 

--- a/rats-apps/src/python/rats/apps/_annotations.py
+++ b/rats-apps/src/python/rats/apps/_annotations.py
@@ -57,6 +57,9 @@ class FunctionAnnotationsBuilder:
     def add(self, namespace: str, service_id: ServiceId[T_ServiceType]) -> None:
         self._service_ids[namespace].append(service_id)
 
+    def get_service_names(self, namespace: str) -> tuple[str, ...]:
+        return tuple(s.name for s in self._service_ids.get(namespace, []))
+
     def make(self, name: str) -> tuple[GroupAnnotations, ...]:
         return tuple(
             [
@@ -130,8 +133,14 @@ def container(
 
 
 def _get_method_service_id_name(method: Callable[..., Any]) -> str:
-    service_name = f"__rats_auto_method_service_id_:{method.__module__}.{method.__qualname__}"
-    return service_name
+    existing_names = _get_annotations_builder(method).get_service_names(
+        ProviderNamespaces.SERVICES
+    )
+    if existing_names:
+        return existing_names[0]
+    else:
+        service_name = f"__rats_auto_method_service_id_:{method.__module__}.{method.__qualname__}"
+        return service_name
 
 
 def method_service_id(method: Callable[..., T_ServiceType]) -> ServiceId[T_ServiceType]:

--- a/rats-apps/src/python/rats/apps/_scoping.py
+++ b/rats-apps/src/python/rats/apps/_scoping.py
@@ -8,6 +8,10 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
+def scope_service_name(module_name: str, cls_name: str, name: str) -> str:
+    return f"{module_name}:{cls_name}[{name}]"
+
+
 def autoscope(cls: type[T]) -> type[T]:
     """
     Decorator that replaces all ServiceId instances in the class with scoped ServiceId instances.
@@ -22,7 +26,7 @@ def autoscope(cls: type[T]) -> type[T]:
             if not isinstance(result, ServiceId):
                 return result
 
-            return ServiceId[Any](f"{cls.__module__}:{cls.__name__}[{result.name}]")
+            return ServiceId[Any](scope_service_name(cls.__module__, cls.__name__, result.name))
 
         return cast(FunctionType, wrapper)
 
@@ -37,7 +41,7 @@ def autoscope(cls: type[T]) -> type[T]:
             if not isinstance(non_ns, ServiceId):
                 continue
 
-            prop = ServiceId[Any](f"{cls.__module__}:{cls.__name__}[{non_ns.name}]")
+            prop = ServiceId[Any](scope_service_name(cls.__module__, cls.__name__, non_ns.name))
             setattr(cls, prop_name, prop)
 
     return cls

--- a/rats-apps/test/python/rats_test/apps/example/__init__.py
+++ b/rats-apps/test/python/rats_test/apps/example/__init__.py
@@ -1,4 +1,5 @@
 from ._app import ExampleApp
+from ._dummy_containers import DummyContainerServiceIds
 from ._example_fallbacks import (
     ExampleFallbackPlugin1,
     ExampleFallbackPlugin2,
@@ -10,6 +11,7 @@ from ._storage import StorageClient, StorageSettings
 from ._storage_plugin import ExampleStoragePlugin
 
 __all__ = [
+    "DummyContainerServiceIds",
     "ExampleApp",
     "ExampleConfigIds",
     "ExampleConfigIds",

--- a/rats-apps/test/python/rats_test/apps/example/_app.py
+++ b/rats-apps/test/python/rats_test/apps/example/_app.py
@@ -1,9 +1,9 @@
 from collections.abc import Callable
 
 from rats import apps
-from rats.apps import Container
-from rats.apps._composite_container import CompositeContainer
-from rats.apps._plugin_container import PluginContainers
+from rats.apps import CompositeContainer, Container, PluginContainers
+
+from ._dummy_containers import DummyContainer
 
 
 class ExampleApp(apps.AnnotatedContainer):
@@ -11,6 +11,10 @@ class ExampleApp(apps.AnnotatedContainer):
 
     def __init__(self, *plugins: Callable[[Container], Container]):
         self._plugins = plugins
+
+    @apps.container()
+    def dummy(self) -> Container:
+        return DummyContainer(self)
 
     @apps.container()
     def runtime_plugins(self) -> Container:

--- a/rats-apps/test/python/rats_test/apps/example/_dummies.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummies.py
@@ -1,0 +1,21 @@
+from typing import Protocol
+
+
+class ITag(Protocol):
+    def get_tag(self) -> str: ...
+
+
+class Tag1:
+    def __init__(self, ns: str) -> None:
+        self._ns = ns
+
+    def get_tag(self) -> str:
+        return f"{self._ns}:t1"
+
+
+class Tag2:
+    def __init__(self, ns: str) -> None:
+        self._ns = ns
+
+    def get_tag(self) -> str:
+        return f"{self._ns}:t2"

--- a/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
@@ -18,7 +18,7 @@ class DummyContainer1(apps.AnnotatedContainer):
 
     # Declaring a service without a service id.  The id will be automatically generated from the
     # fully qualified name of the method.
-    @apps.service()
+    @apps.autoid_service
     def unnamed_service1(self) -> Tag1:
         return Tag1("c1.s1")
 
@@ -34,7 +34,7 @@ class DummyContainer1(apps.AnnotatedContainer):
         return self._app.get(apps.method_service_id(self.unnamed_service1))
 
     # Again without a service id, but this service will be made public below.
-    @apps.service()
+    @apps.autoid_service
     def tag2(self) -> Tag2:
         # Calling a service using the private service id.
         return self._app.get(_PrivateIds.SERVICE2)
@@ -44,7 +44,7 @@ class DummyContainer1(apps.AnnotatedContainer):
         # Within a container, you can also directly call the service method.
         return self.unnamed_service2()
 
-    @apps.service()
+    @apps.autoid_service
     def tag1b(self) -> Tag1:
         # Calling a service from another container using its public service id.
         return self._app.get(DummyContainerServiceIds.C2T1)
@@ -58,11 +58,11 @@ class DummyContainer2(apps.AnnotatedContainer):
 
     # Declaring a service without a service id.  We are using a method name already used in
     # DummyContainer1, to test that they are not confused.
-    @apps.service()
+    @apps.autoid_service
     def unnamed_service1(self) -> Tag1:
         return Tag1("c2.s1")
 
-    @apps.service()
+    @apps.autoid_service
     def tag1(self) -> Tag1:
         return self._app.get(apps.method_service_id(self.unnamed_service1))
 

--- a/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
@@ -7,6 +7,7 @@ from ._dummies import ITag, Tag1, Tag2
 class _PrivateIds:
     SERVICE2 = apps.ServiceId[Tag2]("service2")
     C1T1 = apps.ServiceId[ITag]("c1t1")
+    C1T2a = apps.ServiceId[Tag2]("c1t2a")
 
 
 class DummyContainer1(apps.AnnotatedContainer):
@@ -38,7 +39,7 @@ class DummyContainer1(apps.AnnotatedContainer):
         # Calling a service using the private service id.
         return self._app.get(_PrivateIds.SERVICE2)
 
-    @apps.service()
+    @apps.service(_PrivateIds.C1T2a)
     def tag2a(self) -> Tag2:
         # Within a container, you can also directly call the service method.
         return self.unnamed_service2()
@@ -74,8 +75,11 @@ class DummyContainer(apps.CompositeContainer):
 # Declaring public service ids for the services we want to expose outside this module.
 # This is the only class defined in this module that would be exposed outside the package.
 class DummyContainerServiceIds:
+    # Take a private id and make it public.
     C1T1 = _PrivateIds.C1T1
+    # Make public ids for a services with auto-generated ids.
     C1T2 = apps.method_service_id(DummyContainer1.tag2)
-    C1T2a = apps.method_service_id(DummyContainer1.tag2a)
     C1T1b = apps.method_service_id(DummyContainer1.tag1b)
     C2T1 = apps.method_service_id(DummyContainer2.tag1)
+    # The same mechanism can be used for services declared with service ids.
+    C1T2a = apps.method_service_id(DummyContainer1.tag2a)

--- a/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
@@ -1,0 +1,81 @@
+from rats import apps
+
+from ._dummies import ITag, Tag1, Tag2
+
+
+@apps.autoscope
+class _PrivateIds:
+    SERVICE2 = apps.ServiceId[Tag2]("service2")
+    C1T1 = apps.ServiceId[ITag]("c1t1")
+
+
+class DummyContainer1(apps.AnnotatedContainer):
+    _app: apps.Container
+
+    def __init__(self, app: apps.Container) -> None:
+        self._app = app
+
+    # Declaring a service without a service id.  The id will be automatically generated from the
+    # fully qualified name of the method.
+    @apps.service()
+    def unnamed_service1(self) -> Tag1:
+        return Tag1("c1.s1")
+
+    # Declaring a service with a private service id.
+    @apps.service(_PrivateIds.SERVICE2)
+    def unnamed_service2(self) -> Tag2:
+        return Tag2("c1.s2")
+
+    # Declaring a service with a private service id.  Will be made public below.
+    @apps.service(_PrivateIds.C1T1)
+    def tag1(self) -> Tag1:
+        # Calling a service by its method name.
+        return self._app.get(apps.method_service_id(self.unnamed_service1))
+
+    # Again without a service id, but this service will be made public below.
+    @apps.service()
+    def tag2(self) -> Tag2:
+        # Calling a service using the private service id.
+        return self._app.get(_PrivateIds.SERVICE2)
+
+    @apps.service()
+    def tag2a(self) -> Tag2:
+        # Within a container, you can also directly call the service method.
+        return self.unnamed_service2()
+
+    @apps.service()
+    def tag1b(self) -> Tag1:
+        # Calling a service from another container using its public service id.
+        return self._app.get(DummyContainerServiceIds.C2T1)
+
+
+class DummyContainer2(apps.AnnotatedContainer):
+    _app: apps.Container
+
+    def __init__(self, app: apps.Container) -> None:
+        self._app = app
+
+    # Declaring a service without a service id.  We are using a method name already used in
+    # DummyContainer1, to test that they are not confused.
+    @apps.service()
+    def unnamed_service1(self) -> Tag1:
+        return Tag1("c2.s1")
+
+    @apps.service()
+    def tag1(self) -> Tag1:
+        return self._app.get(apps.method_service_id(self.unnamed_service1))
+
+
+class DummyContainer(apps.CompositeContainer):
+    def __init__(self, app: apps.Container) -> None:
+        super().__init__(DummyContainer1(app), DummyContainer2(app))
+
+
+# Declaring public service ids for the services we want to expose outside this module.
+# This is the only class defined in this module that would be exposed outside the package.
+class DummyContainerServiceIds:
+    C1T1 = _PrivateIds.C1T1
+    C1T2 = apps.method_service_id(DummyContainer1.tag2)
+    C1T2a = apps.method_service_id(DummyContainer1.tag2a)
+    C1T1b = apps.method_service_id(DummyContainer1.tag1b)
+    C2T1 = apps.method_service_id(DummyContainer2.tag1)

--- a/rats-apps/test/python/rats_test/apps/test_annotated_container.py
+++ b/rats-apps/test/python/rats_test/apps/test_annotated_container.py
@@ -34,6 +34,18 @@ class TestAnnotatedContainer:
             example.ExampleGroupsPlugin2,
         )
 
+    def test_service_retrieval_via_unnamed_services(self) -> None:
+        c1t1 = self._app_1.get(example.DummyContainerServiceIds.C1T1)
+        c1t2 = self._app_1.get(example.DummyContainerServiceIds.C1T2)
+        c1t2a = self._app_1.get(example.DummyContainerServiceIds.C1T2a)
+        c1t1b = self._app_1.get(example.DummyContainerServiceIds.C1T1b)
+        c2t1 = self._app_1.get(example.DummyContainerServiceIds.C2T1)
+        assert c1t1.get_tag() == "c1.s1:t1"
+        assert c1t2.get_tag() == "c1.s2:t2"
+        assert c1t2a is c1t2
+        assert c2t1.get_tag() == "c2.s1:t1"
+        assert c1t1b is c2t1
+
     def test_service_retrieval(self) -> None:
         storage = self._app_1.get(example.ExampleIds.STORAGE)
         storage.save("msg", "hello")


### PR DESCRIPTION
* Declare services using the `autoid_service` decorator without providing a service id.  The service id will be auto-generated from the fully qualified method name.
* `method_service_id` gets the service id for a (bound or unbound) method.  This can be used to get an auto-generated service id in order to call the service from the same container, or in order to make the service id public.  `method_service_id` works for manually defined service ids too, to ensure usage does not break when changing the way the service was declared.
* Examples for usage of this and for private/public services in rats-apps/test/python/rats_test/apps/example/_dummy_containers.py.
