### PR TITLE
refactor: disallow calling service methods directly

### DIFF
--- a/rats-apps/src/python/rats/apps/__init__.py
+++ b/rats-apps/src/python/rats/apps/__init__.py
@@ -7,6 +7,7 @@ domain.
 
 from ._annotations import (
     AnnotatedContainer,
+    ServiceMethodArg,
     autoid_service,
     config,
     container,
@@ -48,4 +49,5 @@ __all__ = [
     "group",
     "method_service_id",
     "service",
+    "ServiceMethodArg",
 ]

--- a/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
@@ -7,7 +7,7 @@ from ._dummies import ITag, Tag1, Tag2
 class _PrivateIds:
     SERVICE2 = apps.ServiceId[Tag2]("service2")
     C1T1 = apps.ServiceId[ITag]("c1t1")
-    C1T2a = apps.ServiceId[Tag2]("c1t2a")
+    C1T2 = apps.ServiceId[Tag2]("c1t2")
 
 
 class DummyContainer1(apps.AnnotatedContainer):
@@ -34,15 +34,10 @@ class DummyContainer1(apps.AnnotatedContainer):
         return self._app.get(apps.method_service_id(self.unnamed_service1))
 
     # Again without a service id, but this service will be made public below.
-    @apps.autoid_service
+    @apps.service(_PrivateIds.C1T2)
     def tag2(self) -> Tag2:
         # Calling a service using the private service id.
         return self._app.get(_PrivateIds.SERVICE2)
-
-    @apps.service(_PrivateIds.C1T2a)
-    def tag2a(self) -> Tag2:
-        # Within a container, you can also directly call the service method.
-        return self.unnamed_service2()
 
     @apps.autoid_service
     def tag1b(self) -> Tag1:
@@ -78,8 +73,7 @@ class DummyContainerServiceIds:
     # Take a private id and make it public.
     C1T1 = _PrivateIds.C1T1
     # Make public ids for a services with auto-generated ids.
-    C1T2 = apps.method_service_id(DummyContainer1.tag2)
     C1T1b = apps.method_service_id(DummyContainer1.tag1b)
     C2T1 = apps.method_service_id(DummyContainer2.tag1)
     # The same mechanism can be used for services declared with service ids.
-    C1T2a = apps.method_service_id(DummyContainer1.tag2a)
+    C1T2 = apps.method_service_id(DummyContainer1.tag2)

--- a/rats-apps/test/python/rats_test/apps/test_annotated_container.py
+++ b/rats-apps/test/python/rats_test/apps/test_annotated_container.py
@@ -1,4 +1,3 @@
-# type: ignore[reportUninitializedInstanceVariable]
 import pytest
 
 from rats import apps
@@ -6,12 +5,12 @@ from rats_test.apps import example
 
 
 class TestAnnotatedContainer:
-    _app_1: example.ExampleApp
-    _app_fallback_1: example.ExampleApp
-    _app_fallback_2: example.ExampleApp
-    _app_fallback_3: example.ExampleApp
-    _app_groups_1: example.ExampleApp
-    _app_groups_2: example.ExampleApp
+    _app_1: example.ExampleApp  # type: ignore[reportUninitializedInstanceVariable]
+    _app_fallback_1: example.ExampleApp  # type: ignore[reportUninitializedInstanceVariable]
+    _app_fallback_2: example.ExampleApp  # type: ignore[reportUninitializedInstanceVariable]
+    _app_fallback_3: example.ExampleApp  # type: ignore[reportUninitializedInstanceVariable]
+    _app_groups_1: example.ExampleApp  # type: ignore[reportUninitializedInstanceVariable]
+    _app_groups_2: example.ExampleApp  # type: ignore[reportUninitializedInstanceVariable]
 
     def setup_method(self) -> None:
         self._app_1 = example.ExampleApp()
@@ -37,14 +36,20 @@ class TestAnnotatedContainer:
     def test_service_retrieval_via_unnamed_services(self) -> None:
         c1t1 = self._app_1.get(example.DummyContainerServiceIds.C1T1)
         c1t2 = self._app_1.get(example.DummyContainerServiceIds.C1T2)
-        c1t2a = self._app_1.get(example.DummyContainerServiceIds.C1T2a)
         c1t1b = self._app_1.get(example.DummyContainerServiceIds.C1T1b)
         c2t1 = self._app_1.get(example.DummyContainerServiceIds.C2T1)
         assert c1t1.get_tag() == "c1.s1:t1"
         assert c1t2.get_tag() == "c1.s2:t2"
-        assert c1t2a is c1t2
         assert c2t1.get_tag() == "c2.s1:t1"
         assert c1t1b is c2t1
+
+    def test_cannot_call_service_methods_directly(self) -> None:
+        with pytest.raises(TypeError):
+            # Try to access the container method directly.
+            # Should fail because the method has been decorated with @container, which is a type
+            # of service decorator, and all those add a dummy argument to the method to prevent it
+            # from being called directly.
+            self._app_1.dummy()  # type: ignore[reportCallIssue]
 
     def test_service_retrieval(self) -> None:
         storage = self._app_1.get(example.ExampleIds.STORAGE)

--- a/rats-processors/src/python/rats/pipelines_app/_decorators.py
+++ b/rats-processors/src/python/rats/pipelines_app/_decorators.py
@@ -7,7 +7,7 @@ from rats.processors import ux
 
 T_ServiceType = TypeVar("T_ServiceType")
 P = ParamSpec("P")
-T_Container = TypeVar("T_Container", bound=apps.Container)
+T_Container = TypeVar("T_Container", bound=apps.AnnotatedContainer)
 TInputs = TypeVar("TInputs", bound=ux.Inputs, covariant=True)
 TOutputs = TypeVar("TOutputs", bound=ux.Outputs, covariant=True)
 
@@ -51,14 +51,14 @@ class task(Generic[TInputs, TOutputs]):
     def __new__(
         cls,
         method: Callable[Concatenate[T_Container, P], ux.ProcessorOutput],
-    ) -> Callable[[T_Container], ux.Pipeline[TInputs, TOutputs]]:
+    ) -> Callable[[T_Container, apps.ServiceMethodArg], ux.Pipeline[TInputs, TOutputs]]:
         task_method = _method_to_task_provider[TInputs, TOutputs](method)
         return apps.autoid_service(task_method)
 
 
 def pipeline(
     pipeline_method: Callable[[T_Container], ux.Pipeline[ux.TInputs, ux.TOutputs]],
-) -> Callable[[T_Container], ux.Pipeline[ux.TInputs, ux.TOutputs]]:
+) -> Callable[[T_Container, apps.ServiceMethodArg], ux.Pipeline[ux.TInputs, ux.TOutputs]]:
     """Decorator creating a pipeline service.
 
     The name of the pipeline will be name of the method.

--- a/rats-processors/test/python/rats_test/pipelines_app/example/_complex_pipeline.py
+++ b/rats-processors/test/python/rats_test/pipelines_app/example/_complex_pipeline.py
@@ -28,12 +28,12 @@ class ExampleComplexPipelineBuilder(rpa.PipelineContainer):
     @rpa.pipeline
     def train_and_test_pipeline(self) -> ux.UPipeline:
         train = (
-            self.train_pipeline()
+            self.get(apps.method_service_id(self.train_pipeline))
             .rename_inputs(dict(url="url.train"))
             .rename_outputs(dict(message="message.train"))
         )
         test = (
-            self.test_pipeline()
+            self.get(apps.method_service_id(self.test_pipeline))
             .rename_inputs(dict(url="url.test"))
             .rename_outputs(dict(message="message.test"))
         )

--- a/rats-processors/test/python/rats_test/pipelines_app/example/_simple_typed_pipeline.py
+++ b/rats-processors/test/python/rats_test/pipelines_app/example/_simple_typed_pipeline.py
@@ -120,14 +120,14 @@ class ExampleSimpleTypedPipelineBuilder(rpa.PipelineContainer):
 
     @rpa.pipeline
     def train_pipeline(self) -> TrainPipeline:
-        load = self.load_data()
+        load = self.get(apps.method_service_id(self.load_data))
         train = self.get(apps.method_service_id(self.train_model))
         p = self.combine([load, train], dependencies=[load.outputs.data >> train.inputs.data])
         return cast(TrainPipeline, p)
 
     @rpa.pipeline
     def test_pipeline(self) -> TestPipeline:
-        load = self.load_data()
+        load = self.get(apps.method_service_id(self.load_data))
         test = self.get(apps.method_service_id(self.test_model))
         p = self.combine([load, test], dependencies=[load.outputs.data >> test.inputs.data])
         return cast(TestPipeline, p)

--- a/rats-processors/test/python/rats_test/pipelines_app/example/_simple_untyped_pipeline.py
+++ b/rats-processors/test/python/rats_test/pipelines_app/example/_simple_untyped_pipeline.py
@@ -26,7 +26,7 @@ class ExampleSimpleUntypedPipelineBuilder(rpa.PipelineContainer):
 
     @rpa.pipeline
     def p1(self) -> ux.UPipeline:
-        p1 = self.load_data()
+        p1 = self.get(apps.method_service_id(self.load_data))
         p2 = self.get(apps.method_service_id(self.train_model))
         p = self.combine([p1, p2], dependencies=[p1 >> p2])
         return p


### PR DESCRIPTION
If we decide that it is wrong to call methods decorated by `@service` and similar decorators directly, this PR would enforce that both statically and dynamically.

It does so by having the decorators add a dummy argument of type `ServiceMethodArg` to the methods.  `ServiceMethodArg` is exposed publicly so downstream packages can wrap over these decorators with decorators of their own (e.g. `@task` and `@pipeline`).  However, the constructor of `ServiceMethodArg` takes a dummy parameter of type `_ServiceMethodArgArg` which is private, so only the `_annotations` module can create a `ServiceMethodArg`, and therefore only that module can call the annotated methods.  I think.

Not sure we actually want to go this way.