### PR TITLE
try to fix the monorepo plugin support

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -61,6 +61,7 @@ runs:
       shell: bash
       run: |
         pipx install poetry
+        poetry self add poetry-monorepo-dependency-plugin
     - id: "install-devtools"
       if: ${{ inputs.install-devtools }}
       name: "install-devtools"


### PR DESCRIPTION
this is causing processors component to fail ci in `main` because the package metadata contains local dependencies. the monorepo plugin should fix these dependencies at build time.