### PR TITLE
Fix/service caching

### DIFF
--- a/rats-apps/.vscode/settings.json
+++ b/rats-apps/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/rats-apps/src/python/rats/apps/_container.py
+++ b/rats-apps/src/python/rats/apps/_container.py
@@ -125,10 +125,14 @@ class Container(Protocol):
         groups = tates.with_group(namespace, cast(NamedTuple, group_id))
 
         for annotation in groups.annotations:
-            if not hasattr(self, f"__rats_cache_{annotation.name}"):
-                setattr(self, f"__rats_cache_{annotation.name}", getattr(self, annotation.name)())
+            if not hasattr(self, f"__rats_cache_{annotation.name}_{group_id.name}"):
+                setattr(
+                    self,
+                    f"__rats_cache_{annotation.name}_{group_id.name}",
+                    getattr(self, annotation.name)(),
+                )
 
-            yield getattr(self, f"__rats_cache_{annotation.name}")
+            yield getattr(self, f"__rats_cache_{annotation.name}_{group_id.name}")
 
         for annotation in containers.annotations:
             if not hasattr(self, f"__rats_container_cache_{annotation.name}"):
@@ -138,7 +142,7 @@ class Container(Protocol):
                     getattr(self, annotation.name)(),
                 )
 
-            c = getattr(self, f"__rats_container_cache_{annotation.name}")
+            c: Container = getattr(self, f"__rats_container_cache_{annotation.name}")
             yield from c.get_namespaced_group(namespace, group_id)
 
 

--- a/rats-apps/test/python/rats_test/apps/example/_dummies.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummies.py
@@ -8,17 +8,9 @@ class ITag(Protocol):
         """Get the tag."""
 
 
-class Tag1:
+class Tag:
     def __init__(self, ns: str) -> None:
         self._ns = ns
 
     def get_tag(self) -> str:
-        return f"{self._ns}:t1"
-
-
-class Tag2:
-    def __init__(self, ns: str) -> None:
-        self._ns = ns
-
-    def get_tag(self) -> str:
-        return f"{self._ns}:t2"
+        return self._ns

--- a/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
+++ b/rats-apps/test/python/rats_test/apps/example/_dummy_containers.py
@@ -1,13 +1,14 @@
 from rats import apps
 
-from ._dummies import ITag, Tag1, Tag2
+from ._dummies import ITag, Tag
 
 
 @apps.autoscope
 class _PrivateIds:
-    SERVICE2 = apps.ServiceId[Tag2]("service2")
-    C1T1 = apps.ServiceId[ITag]("c1t1")
-    C1T2a = apps.ServiceId[Tag2]("c1t2a")
+    C1S1B = apps.ServiceId[ITag]("c1s1b")
+    C1S1C = apps.ServiceId[ITag]("c1s1c")
+    C1S2A = apps.ServiceId[ITag]("c1s2a")
+    C1S2B = apps.ServiceId[ITag]("c1s2b")
 
 
 class DummyContainer1(apps.Container):
@@ -19,36 +20,32 @@ class DummyContainer1(apps.Container):
     # Declaring a service without a service id.  The id will be automatically generated from the
     # fully qualified name of the method.
     @apps.autoid_service
-    def unnamed_service1(self) -> Tag1:
-        return Tag1("c1.s1")
+    def unnamed_service(self) -> ITag:
+        return Tag("c1.s1")
 
     # Declaring a service with a private service id.  Will be made public below.
-    @apps.service(_PrivateIds.C1T1)
-    def tag1(self) -> Tag1:
+    @apps.service(_PrivateIds.C1S1B)
+    def c1s1b(self) -> ITag:
         # Calling a service by its method name.
-        return self._app.get(apps.autoid(self.unnamed_service1))
+        return self._app.get(apps.autoid(self.unnamed_service))
 
-    # Again without a service id, but this service will be made public below.
-    @apps.autoid_service
-    def tag2(self) -> Tag2:
-        # Calling a service using the private service id.
-        return self._app.get(_PrivateIds.SERVICE2)
-
-    @apps.service(_PrivateIds.C1T2a)
-    def tag2a(self) -> Tag2:
+    @apps.service(_PrivateIds.C1S1C)
+    def c1s1c(self) -> ITag:
         # Within a container, you can also directly call the service method.
         # But this version is not cached by apps.Container
-        return self.unnamed_service2()
+        return self.unnamed_service()
 
-    # Declaring a service with a private service id.
-    @apps.service(_PrivateIds.SERVICE2)
-    def unnamed_service2(self) -> Tag2:
-        return Tag2("c1.s2")
+    # Declaring a service with multiple service ids.
+    # Each service id should be cached separately.
+    @apps.service(_PrivateIds.C1S2A)
+    @apps.service(_PrivateIds.C1S2B)
+    def c1s2(self) -> ITag:
+        return Tag("c1.s2")
 
     @apps.autoid_service
-    def tag1b(self) -> Tag1:
+    def c2s1a(self) -> ITag:
         # Calling a service from another container using its public service id.
-        return self._app.get(DummyContainerServiceIds.C2T1)
+        return self._app.get(DummyContainerServiceIds.C2S1B)
 
 
 class DummyContainer2(apps.Container):
@@ -60,12 +57,8 @@ class DummyContainer2(apps.Container):
     # Declaring a service without a service id.  We are using a method name already used in
     # DummyContainer1, to test that they are not confused.
     @apps.autoid_service
-    def unnamed_service1(self) -> Tag1:
-        return Tag1("c2.s1")
-
-    @apps.autoid_service
-    def tag1(self) -> Tag1:
-        return self._app.get(apps.autoid(self.unnamed_service1))
+    def unnamed_service(self) -> ITag:
+        return Tag("c2.s1")
 
 
 class DummyContainer(apps.Container):
@@ -83,11 +76,12 @@ class DummyContainer(apps.Container):
 # Declaring public service ids for the services we want to expose outside this module.
 # This is the only class defined in this module that would be exposed outside the package.
 class DummyContainerServiceIds:
-    # Take a private id and make it public.
-    C1T1 = _PrivateIds.C1T1
-    # Make public ids for a services with auto-generated ids.
-    C1T2 = apps.autoid(DummyContainer1.tag2)
-    C1T1b = apps.autoid(DummyContainer1.tag1b)
-    C2T1 = apps.autoid(DummyContainer2.tag1)
-    # The same mechanism can be used for services declared with service ids.
-    C1T2a = apps.autoid(DummyContainer1.tag2a)
+    C1S1A = apps.autoid(DummyContainer1.unnamed_service)
+    C1S1B = _PrivateIds.C1S1B
+    C1S1C = _PrivateIds.C1S1C
+
+    C1S2A = _PrivateIds.C1S2A
+    C1S2B = _PrivateIds.C1S2B
+
+    C2S1A = apps.autoid(DummyContainer1.c2s1a)
+    C2S1B = apps.autoid(DummyContainer2.unnamed_service)

--- a/rats-apps/test/python/rats_test/apps/test_service_caching.py
+++ b/rats-apps/test/python/rats_test/apps/test_service_caching.py
@@ -1,0 +1,44 @@
+from .example import DummyContainerServiceIds, ExampleApp
+
+
+class TestServiceCaching:
+    _app: ExampleApp = ExampleApp()
+
+    def test_service_caching(self) -> None:
+        c1s1a = self._app.get(DummyContainerServiceIds.C1S1A)
+        c1s1a_ = self._app.get(DummyContainerServiceIds.C1S1A)
+        c1s1b = self._app.get(DummyContainerServiceIds.C1S1B)
+        c1s1b_ = self._app.get(DummyContainerServiceIds.C1S1B)
+        c1s1c = self._app.get(DummyContainerServiceIds.C1S1C)
+        c1s1c_ = self._app.get(DummyContainerServiceIds.C1S1C)
+
+        assert c1s1a is c1s1a_
+        assert c1s1b is c1s1b_
+        assert c1s1c is c1s1c_
+        assert c1s1a.get_tag() == "c1.s1"
+        assert c1s1b.get_tag() == "c1.s1"
+        assert c1s1c.get_tag() == "c1.s1"
+        assert c1s1a is c1s1b
+        assert c1s1a is not c1s1c
+
+        c1s2a = self._app.get(DummyContainerServiceIds.C1S2A)
+        c1s2a_ = self._app.get(DummyContainerServiceIds.C1S2A)
+        c1s2b = self._app.get(DummyContainerServiceIds.C1S2B)
+        c1s2b_ = self._app.get(DummyContainerServiceIds.C1S2B)
+
+        assert c1s2a is c1s2a_
+        assert c1s2b is c1s2b_
+        assert c1s2a.get_tag() == "c1.s2"
+        assert c1s2b.get_tag() == "c1.s2"
+        assert c1s2a is not c1s2b
+
+        c2s1a = self._app.get(DummyContainerServiceIds.C2S1A)
+        c2s1a_ = self._app.get(DummyContainerServiceIds.C2S1A)
+        c2s1b = self._app.get(DummyContainerServiceIds.C2S1B)
+        c2s1b_ = self._app.get(DummyContainerServiceIds.C2S1B)
+
+        assert c2s1a is c2s1a_
+        assert c2s1b is c2s1b_
+        assert c2s1a.get_tag() == "c2.s1"
+        assert c2s1b.get_tag() == "c2.s1"
+        assert c2s1a is c2s1b


### PR DESCRIPTION
When a single service-provider-method is decorated with multiple service ids, caching should be separated for each service id.
The cache key was based on `annotation.name`, which is the name of the method, so was shared across service ids in the above scenario.
This PR adds tests for service caching, and fixes the cache key so those tests pass.