### PR TITLE
rename cli.CommandContainer to cli.Container and add CompositeContainer

### DIFF
--- a/rats-apps/src/python/rats/cli/__init__.py
+++ b/rats-apps/src/python/rats/cli/__init__.py
@@ -2,7 +2,7 @@
 
 from ._annotations import CommandId, command, get_class_commands, get_class_groups, group
 from ._app import ClickApp
-from ._container import CommandContainer
+from ._container import Container
 from ._plugin import PluginContainer, PluginServices, attach, create_group
 
 __all__ = [
@@ -16,5 +16,5 @@ __all__ = [
     "ClickApp",
     "PluginServices",
     "CommandId",
-    "CommandContainer",
+    "Container",
 ]

--- a/rats-apps/src/python/rats/cli/__main__.py
+++ b/rats-apps/src/python/rats/cli/__main__.py
@@ -9,7 +9,7 @@ from rats import apps, cli
 logger = logging.getLogger(__name__)
 
 
-class ExampleCommands(cli.CommandContainer):
+class ExampleCommands(cli.Container):
     """An example collection of cli commands."""
 
     @cli.command()

--- a/rats-apps/src/python/rats/cli/_app.py
+++ b/rats-apps/src/python/rats/cli/_app.py
@@ -4,7 +4,7 @@ import click
 
 from rats import apps
 
-from ._container import CommandContainer
+from ._container import Container
 
 
 @final
@@ -12,12 +12,12 @@ class ClickApp(apps.Executable):
     """..."""
 
     _group: click.Group
-    _commands: CommandContainer
+    _commands: Container
 
     def __init__(
         self,
         group: click.Group,
-        commands: CommandContainer,
+        commands: Container,
     ) -> None:
         """Not sure this is the right interface."""
         self._group = group

--- a/rats-apps/src/python/rats/cli/_container.py
+++ b/rats-apps/src/python/rats/cli/_container.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 from functools import partial
-from typing import Any, Protocol
+from typing import Any, Protocol, final
 
 import click
 
@@ -10,7 +10,7 @@ from ._annotations import get_class_commands
 logger = logging.getLogger(__name__)
 
 
-class CommandContainer(Protocol):
+class Container(Protocol):
     """A container that can attach click commands to a click group."""
 
     def attach(self, group: click.Group) -> None:
@@ -46,3 +46,15 @@ class CommandContainer(Protocol):
                             params=params,
                         )
                     )
+
+
+@final
+class CompositeContainer(Container):
+    _containers: tuple[Container, ...]
+
+    def __init__(self, *containers: Container) -> None:
+        self._containers = containers
+
+    def attach(self, group: click.Group) -> None:
+        for container in self._containers:
+            container.attach(group)

--- a/rats-apps/src/python/rats/cli/_plugin.py
+++ b/rats-apps/src/python/rats/cli/_plugin.py
@@ -4,10 +4,10 @@ import click
 
 from rats import apps
 
-from ._container import CommandContainer
+from ._container import Container
 
 
-def create_group(group: click.Group, container: CommandContainer) -> click.Group:
+def create_group(group: click.Group, container: Container) -> click.Group:
     container.attach(group)
     return group
 

--- a/rats-devtools/src/python/rats/amlruntime/_commands.py
+++ b/rats-devtools/src/python/rats/amlruntime/_commands.py
@@ -11,7 +11,7 @@ from rats import apps, cli, projects
 logger = logging.getLogger(__name__)
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     _project_tools: apps.Provider[projects.ProjectTools]
     _cwd_component_tools: apps.Provider[projects.ComponentTools]
     _worker_node_runtime: apps.Provider[apps.Runtime]

--- a/rats-devtools/src/python/rats/amlruntime/_plugin.py
+++ b/rats-devtools/src/python/rats/amlruntime/_plugin.py
@@ -31,7 +31,7 @@ class PluginServices:
     AML_CLIENT = apps.ServiceId[MLClient]("aml-client")
     AML_ENVIRONMENT_OPS = apps.ServiceId[EnvironmentOperations]("aml-environment-ops")
     AML_JOB_OPS = apps.ServiceId[JobOperations]("aml-job-ops")
-    COMMANDS = apps.ServiceId[cli.CommandContainer]("commands")
+    COMMANDS = apps.ServiceId[cli.Container]("commands")
 
     MAIN_EXE = apps.ServiceId[apps.Executable]("main-exe")
     MAIN_CLICK = apps.ServiceId[click.Group]("main-click")
@@ -73,7 +73,7 @@ class PluginContainer(apps.Container):
         )
 
     @apps.service(PluginServices.COMMANDS)
-    def _commands(self) -> cli.CommandContainer:
+    def _commands(self) -> cli.Container:
         return PluginCommands(
             project_tools=lambda: self._app.get(projects.PluginServices.PROJECT_TOOLS),
             cwd_component_tools=lambda: self._app.get(projects.PluginServices.CWD_COMPONENT_TOOLS),

--- a/rats-devtools/src/python/rats/ci/_commands.py
+++ b/rats-devtools/src/python/rats/ci/_commands.py
@@ -16,7 +16,7 @@ class CiCommandGroups(NamedTuple):
     test: tuple[tuple[str, ...], ...]
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     _project_tools: apps.Provider[projects.ProjectTools]
     _selected_component: apps.Provider[projects.ComponentTools]
     _devtools_component: apps.Provider[projects.ComponentTools]

--- a/rats-devtools/src/python/rats/ci/_plugin.py
+++ b/rats-devtools/src/python/rats/ci/_plugin.py
@@ -20,7 +20,7 @@ class PluginConfigs:
 
 @apps.autoscope
 class PluginServices:
-    COMMANDS = apps.ServiceId[cli.CommandContainer]("commands")
+    COMMANDS = apps.ServiceId[cli.Container]("commands")
     MAIN_EXE = apps.ServiceId[apps.Executable]("main-exe")
     MAIN_CLICK = apps.ServiceId[click.Group]("main-click")
 
@@ -43,7 +43,7 @@ class PluginContainer(apps.Container):
         )
 
     @apps.service(PluginServices.COMMANDS)
-    def _commands(self) -> cli.CommandContainer:
+    def _commands(self) -> cli.Container:
         return PluginCommands(
             project_tools=lambda: self._app.get(projects.PluginServices.PROJECT_TOOLS),
             selected_component=lambda: self._app.get(projects.PluginServices.CWD_COMPONENT_TOOLS),

--- a/rats-devtools/src/python/rats/devtools/_commands.py
+++ b/rats-devtools/src/python/rats/devtools/_commands.py
@@ -6,7 +6,7 @@ from rats import apps, cli, projects
 logger = logging.getLogger(__name__)
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     """These are the base commands you get with devtools."""
 
     _project_tools: apps.Provider[projects.ProjectTools]

--- a/rats-devtools/src/python/rats/devtools/_plugin.py
+++ b/rats-devtools/src/python/rats/devtools/_plugin.py
@@ -22,7 +22,7 @@ class _PluginEvents:
 class PluginServices:
     MAIN_EXE = apps.ServiceId[apps.Executable]("main-exe")
     MAIN_CLICK = apps.ServiceId[click.Group]("main-click")
-    COMMANDS = apps.ServiceId[cli.CommandContainer]("commands")
+    COMMANDS = apps.ServiceId[cli.Container]("commands")
     EVENTS = _PluginEvents
 
 
@@ -64,5 +64,5 @@ class PluginContainer(apps.Container):
         )
 
     @apps.service(PluginServices.COMMANDS)
-    def _commands(self) -> cli.CommandContainer:
+    def _commands(self) -> cli.Container:
         return PluginCommands(lambda: self._app.get(projects.PluginServices.PROJECT_TOOLS))

--- a/rats-devtools/src/python/rats/docs/_commands.py
+++ b/rats-devtools/src/python/rats/docs/_commands.py
@@ -6,7 +6,7 @@ from rats import apps, cli, projects
 logger = logging.getLogger(__name__)
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     _project_tools: apps.Provider[projects.ProjectTools]
     _selected_component: apps.Provider[projects.ComponentTools]
     _devtools_component: apps.Provider[projects.ComponentTools]

--- a/rats-devtools/src/python/rats/docs/_plugin.py
+++ b/rats-devtools/src/python/rats/docs/_plugin.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 @apps.autoscope
 class PluginServices:
-    COMMANDS = apps.ServiceId[cli.CommandContainer]("commands")
+    COMMANDS = apps.ServiceId[cli.Container]("commands")
     MAIN_EXE = apps.ServiceId[apps.Executable]("main-exe")
     MAIN_CLICK = apps.ServiceId[click.Group]("main-click")
 
@@ -35,7 +35,7 @@ class PluginContainer(apps.Container):
         )
 
     @apps.service(PluginServices.COMMANDS)
-    def _commands(self) -> cli.CommandContainer:
+    def _commands(self) -> cli.Container:
         return PluginCommands(
             project_tools=lambda: self._app.get(projects.PluginServices.PROJECT_TOOLS),
             selected_component=lambda: self._app.get(projects.PluginServices.CWD_COMPONENT_TOOLS),

--- a/rats-devtools/src/python/rats/examples/_cli.py
+++ b/rats-devtools/src/python/rats/examples/_cli.py
@@ -1,7 +1,7 @@
 from rats import cli
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     @cli.command()
     def _ping(self) -> None:
         print("ping")

--- a/rats-devtools/src/python/rats/kuberuntime/_commands.py
+++ b/rats-devtools/src/python/rats/kuberuntime/_commands.py
@@ -10,7 +10,7 @@ from rats import apps, cli, projects
 logger = logging.getLogger(__name__)
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     _project_tools: apps.Provider[projects.ProjectTools]
     _cwd_component_tools: apps.Provider[projects.ComponentTools]
     _worker_node_runtime: apps.Provider[apps.Runtime]

--- a/rats-devtools/src/python/rats/kuberuntime/_plugin.py
+++ b/rats-devtools/src/python/rats/kuberuntime/_plugin.py
@@ -12,7 +12,7 @@ from ._commands import PluginCommands
 @apps.autoscope
 class PluginServices:
     K8S_RUNTIME = apps.ServiceId[apps.Runtime]("k8s-runtime")
-    COMMANDS = apps.ServiceId[cli.CommandContainer]("commands")
+    COMMANDS = apps.ServiceId[cli.Container]("commands")
     MAIN_EXE = apps.ServiceId[apps.Executable]("main-exe")
     MAIN_CLICK = apps.ServiceId[click.Group]("main-click")
 
@@ -57,7 +57,7 @@ class PluginContainer(apps.Container):
         )
 
     @apps.service(PluginServices.COMMANDS)
-    def _commands(self) -> cli.CommandContainer:
+    def _commands(self) -> cli.Container:
         return PluginCommands(
             project_tools=lambda: self._app.get(projects.PluginServices.PROJECT_TOOLS),
             cwd_component_tools=lambda: self._app.get(projects.PluginServices.CWD_COMPONENT_TOOLS),

--- a/rats-devtools/src/python/rats/stdruntime/_commands.py
+++ b/rats-devtools/src/python/rats/stdruntime/_commands.py
@@ -7,7 +7,7 @@ from rats import apps, cli
 logger = logging.getLogger(__name__)
 
 
-class PluginCommands(cli.CommandContainer):
+class PluginCommands(cli.Container):
     _standard_runtime: apps.Runtime
 
     def __init__(self, standard_runtime: apps.Runtime) -> None:

--- a/rats-devtools/src/python/rats/stdruntime/_plugin.py
+++ b/rats-devtools/src/python/rats/stdruntime/_plugin.py
@@ -10,7 +10,7 @@ from ._commands import PluginCommands
 
 @apps.autoscope
 class PluginServices:
-    COMMANDS = apps.ServiceId[cli.CommandContainer]("commands")
+    COMMANDS = apps.ServiceId[cli.Container]("commands")
     MAIN_CLICK = apps.ServiceId[click.Group]("main-click")
 
 
@@ -40,7 +40,7 @@ class PluginContainer(apps.Container):
         )
 
     @apps.service(PluginServices.COMMANDS)
-    def _commands(self) -> cli.CommandContainer:
+    def _commands(self) -> cli.Container:
         return PluginCommands(
             standard_runtime=self._app.get(apps.AppServices.STANDARD_RUNTIME),
         )


### PR DESCRIPTION
this is to try and make the packages a little more familiar

- apps.Container has getter methods for application services
- cli.Container has a list of cli commands that can be attached to a group