### PR TITLE
Feature/cli docs and container versions

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -6,8 +6,6 @@
       <module fileurl="file://$PROJECT_DIR$/rats-apps/.idea/rats-apps.iml" filepath="$PROJECT_DIR$/rats-apps/.idea/rats-apps.iml" />
       <module fileurl="file://$PROJECT_DIR$/rats-devtools/.idea/rats-devtools.iml" filepath="$PROJECT_DIR$/rats-devtools/.idea/rats-devtools.iml" />
       <module fileurl="file://$PROJECT_DIR$/rats-examples-sklearn/.idea/rats-examples-sklearn.iml" filepath="$PROJECT_DIR$/rats-examples-sklearn/.idea/rats-examples-sklearn.iml" />
-      <module fileurl="file://$PROJECT_DIR$/rats-pipelines/.idea/rats-pipelines.iml" filepath="$PROJECT_DIR$/rats-pipelines/.idea/rats-pipelines.iml" />
-      <module fileurl="file://$PROJECT_DIR$/rats-processors/.idea/rats-processors.iml" filepath="$PROJECT_DIR$/rats-processors/.idea/rats-processors.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/rats.iml
+++ b/.idea/rats.iml
@@ -8,8 +8,6 @@
       <excludeFolder url="file://$MODULE_DIR$/rats/dist" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="rats-pipelines" />
-    <orderEntry type="module" module-name="rats-processors" />
     <orderEntry type="module" module-name="rats-devtools" />
     <orderEntry type="module" module-name="rats-apps" />
     <orderEntry type="module" module-name="rats-examples-sklearn" />

--- a/rats-apps/docs/index.md
+++ b/rats-apps/docs/index.md
@@ -149,15 +149,15 @@ application is functional in many compute environments.
     we can combine these containers to create applications. The [rats.apps][] module has additional
     libraries to help define different types of applications, designed to help your solutions
     evolve as ideas mature. Our first runnable example was a single instance of the
-    [apps.AppContainer][] interface with an `execute()` method; but a larger project might have
-    a few modules providing different aspects of the application's needs by sharing a set of
+    [rats.apps.AppContainer][] interface with an `execute()` method; but a larger project might
+    have a few modules providing different aspects of the application's needs by sharing a set of
     service ids and a plugin container.
 
 ## Installable Plugins
 
 We use the standard [Entry Points](https://packaging.python.org/en/latest/specifications/entry-points/)
 mechanism to allow authors to make their application extensible. These plugins are instances of
-[apps.Container][] and loaded into applications like our previous examples.
+[rats.apps.Container][] and loaded into applications like our previous examples.
 
 === ":material-file-settings: ~/code/pyproject.toml"
     ```toml

--- a/rats-apps/docs/rats.annotations.md
+++ b/rats-apps/docs/rats.annotations.md
@@ -1,3 +1,6 @@
+---
 title: rats.annotations
 ---
 ::: rats.annotations
+    options:
+        heading_level: 1

--- a/rats-apps/docs/rats.apps.md
+++ b/rats-apps/docs/rats.apps.md
@@ -2,6 +2,8 @@
 title: rats.apps
 ---
 ::: rats.apps
+    options:
+        heading_level: 1
 
 ## Examples
 

--- a/rats-apps/docs/rats.cli.md
+++ b/rats-apps/docs/rats.cli.md
@@ -1,3 +1,6 @@
+---
 title: rats.cli
 ---
 ::: rats.cli
+    options:
+        heading_level: 1

--- a/rats-apps/docs/rats.logs.md
+++ b/rats-apps/docs/rats.logs.md
@@ -1,3 +1,6 @@
+---
 title: rats.logs
 ---
 ::: rats.logs
+    options:
+        heading_level: 1

--- a/rats-apps/pyproject.toml
+++ b/rats-apps/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "rats-apps"
 description = "research analysis tools for building applications"
-version = "0.5.1"
+version = "0.6.0"
 readme = "README.md"
 authors = []
 packages = [

--- a/rats-apps/src/python/rats/apps/_app_containers.py
+++ b/rats-apps/src/python/rats/apps/_app_containers.py
@@ -63,10 +63,11 @@ be used easily in functions that need to defer the construction of an applicatio
 
 class PluginMixin:
     """
-    Mix into your [Container][] classes to add our default constructor.
+    Mix into your [rats.apps.Container][] classes to add our default constructor.
 
     This mixin adds a common constructor to a `Container` in order to quickly create types that
-    are compatible with functions asking for `AppPlugin` and `ContainerPlugin` arguments.
+    are compatible with functions asking for [rats.apps.AppPlugin][] and
+    [rats.apps.ContainerPlugin][] arguments.
 
     !!! warning
         Avoid using mixins as an input type to your functions, because we don't want to restrict

--- a/rats-apps/src/python/rats/cli/__init__.py
+++ b/rats-apps/src/python/rats/cli/__init__.py
@@ -1,16 +1,23 @@
-"""Uses `rats.cli` to streamline the creation of CLI commands written with Click."""
+"""Use `rats.cli` to streamline the creation of CLI commands written with Click."""
 
-from ._annotations import CommandId, command, get_class_commands, get_class_groups, group
+from ._annotations import (
+    AUTO_COMMAND,
+    CommandId,
+    command,
+    get_class_commands,
+    get_class_groups,
+    group,
+)
 from ._app import ClickApp
 from ._container import CompositeContainer, Container
-from ._plugin import PluginServices, attach, create_group
+from ._plugin import attach, create_group
 
 __all__ = [
+    "AUTO_COMMAND",
     "ClickApp",
     "CommandId",
     "CompositeContainer",
     "Container",
-    "PluginServices",
     "attach",
     "command",
     "create_group",

--- a/rats-apps/src/python/rats/cli/_annotations.py
+++ b/rats-apps/src/python/rats/cli/_annotations.py
@@ -8,14 +8,47 @@ from rats import apps
 
 
 class CommandId(NamedTuple):
+    """
+    A small wrapper around the string name of a [click.Command][].
+
+    Used when wanting to specify a custom name for a command within a [rats.cli.Container][] class.
+    See [rats.cli.command][] for more details.
+    """
+
     name: str
 
 
 AUTO_COMMAND = CommandId("__auto__")
+"""
+Causes command names to be generated from the method names in [rats.cli.Container][]'s.
+
+This is the default option for [rats.cli.command][] and [rats.cli.group][] and typically does not
+need to be used directly.
+"""
 T = TypeVar("T", bound=Callable[[Any], Any])
 
 
 def command(command_id: CommandId = AUTO_COMMAND) -> Callable[..., apps.Executable]:
+    """
+    Mark a method in [rats.cli.Container][] instances as a [click.Command][].
+
+    By default, the name of the method is used to generate a dash-separated command name. You can
+    provide a [rats.cli.CommandId][] argument to specify a custom name, for example, if the desired
+    command contains characters that are invalid in method names, like periods.
+
+    ```python
+    from rats import cli
+
+    class Example(cli.Container):
+        @cli.command(cli.CommandId("some.example-command")
+        def _any_method_name(self) -> None:
+            print("this cli command is called some.example-command")
+    ```
+
+    Args:
+        command_id: An optional [rats.cli.CommandId][] to specify the command name.
+    """
+
     def decorator(fn: T) -> T:
         if command_id == AUTO_COMMAND:
             cmd_name = fn.__name__.replace("_", "-").strip("-")
@@ -26,17 +59,31 @@ def command(command_id: CommandId = AUTO_COMMAND) -> Callable[..., apps.Executab
 
 
 def group(command_id: CommandId = AUTO_COMMAND) -> Callable[..., apps.Executable]:
+    """
+    Mark a method in [rats.cli.Container][] instances as a [click.Group][].
+
+    !!! warning
+        It's unclear if this API is useful as-is and will most likely change soon.
+
+    See [rats.cli.command][] for more details.
+
+    Args:
+        command_id: An optional [rats.cli.CommandId][] to specify the group name.
+    """
+
     def decorator(fn: T) -> T:
         if command_id == AUTO_COMMAND:
             return anns.annotation("command-groups", CommandId(fn.__name__.replace("_", "-")))(fn)
-        return anns.annotation("commands", command_id)(fn)
+        return anns.annotation("command-groups", command_id)(fn)
 
     return decorator  # type: ignore[reportReturnType]
 
 
 def get_class_commands(cls: type) -> anns.AnnotationsContainer:
+    """Extracts class methods decorated with [rats.cli.command][]."""
     return anns.get_class_annotations(cls).with_namespace("commands")
 
 
 def get_class_groups(cls: type) -> anns.AnnotationsContainer:
+    """Extracts class methods decorated with [rats.cli.group][]."""
     return anns.get_class_annotations(cls).with_namespace("command-groups")

--- a/rats-apps/src/python/rats/cli/_app.py
+++ b/rats-apps/src/python/rats/cli/_app.py
@@ -9,7 +9,13 @@ from ._container import Container
 
 @final
 class ClickApp(apps.Executable):
-    """..."""
+    """
+    A wrapper to configure and run a [click.Group][] as a [rats.apps.Executable][].
+
+    The [rats.cli.Container][] is attached to the provided [click.Group][] when the
+    [rats.cli.ClickApp.execute][] is called, allowing some simple forms of lazy-loading to keep
+    commands snappy.
+    """
 
     _group: click.Group
     _commands: Container
@@ -19,11 +25,24 @@ class ClickApp(apps.Executable):
         group: click.Group,
         commands: Container,
     ) -> None:
-        """Not sure this is the right interface."""
+        """
+        Provide the [rats.cli.Container][] instance that makes up the wanted cli commands.
+
+        Args:
+            group: group that will be executed by this application.
+            commands: container that will be attached before executing the above group.
+        """
         self._group = group
         self._commands = commands
 
     def execute(self) -> None:
-        """This app executes a click application after letting rats plugins attach commands."""
+        """
+        Attach any commands provided by the [rats.cli.Container][] and then execute the group.
+
+        !!! note
+            Currently, this method runs [click.BaseCommand.main][] without arguments, causing Click
+            to pull the command arguments from [sys.argv][]. If you are needing to change this,
+            skip using this class and implement the custom logic yourself.
+        """
         self._commands.attach(self._group)
         self._group.main()

--- a/rats-apps/src/python/rats/cli/_container.py
+++ b/rats-apps/src/python/rats/cli/_container.py
@@ -11,10 +11,29 @@ logger = logging.getLogger(__name__)
 
 
 class Container(Protocol):
-    """A container that can attach click commands to a click group."""
+    """
+    A container that can attach click commands to a click group.
+
+    !!! example
+        The default protocol implementation detects any methods in the class decorated with the
+        [rats.cli.command][] annotation. Apart from marking the method as a cli command, you can
+        add [click.argument][] and [click.option][] decorators as defined by the click docs.
+
+        ```python
+        from rats import cli
+
+
+        class ExampleCli(cli.Container):
+            @cli.command()
+            @click.argument("something")
+            def my_cmd(self, something: str) -> None:
+                print("this command is automatically detected and attached as my-cmd")
+                print("add a docstring to the method to be used as the --help text")
+        ```
+    """
 
     def attach(self, group: click.Group) -> None:
-        """..."""
+        """Attach this container's provided cli commands to the provided [click.Group][]."""
 
         def cb(_method: Callable[..., None], *args: Any, **kwargs: Any) -> None:
             """
@@ -50,11 +69,14 @@ class Container(Protocol):
 
 @final
 class CompositeContainer(Container):
+    """Take any number of [rats.cli.Container][] instances and expose them as if they were one."""
+
     _containers: tuple[Container, ...]
 
     def __init__(self, *containers: Container) -> None:
         self._containers = containers
 
     def attach(self, group: click.Group) -> None:
+        """Attach the cli commands from all [rats.cli.Container][] instances to the [click.Group][]."""
         for container in self._containers:
             container.attach(group)

--- a/rats-apps/src/python/rats/cli/_container.py
+++ b/rats-apps/src/python/rats/cli/_container.py
@@ -33,7 +33,12 @@ class Container(Protocol):
     """
 
     def attach(self, group: click.Group) -> None:
-        """Attach this container's provided cli commands to the provided [click.Group][]."""
+        """
+        Attach this container's provided cli commands to the provided [click.Group][].
+
+        Args:
+            group: The [click.Group][] we are attaching our commands to.
+        """
 
         def cb(_method: Callable[..., None], *args: Any, **kwargs: Any) -> None:
             """
@@ -74,9 +79,20 @@ class CompositeContainer(Container):
     _containers: tuple[Container, ...]
 
     def __init__(self, *containers: Container) -> None:
+        """
+        Zero or more instances can be provided.
+
+        Args:
+            *containers: Any number of container instances wanting to be merged.
+        """
         self._containers = containers
 
     def attach(self, group: click.Group) -> None:
-        """Attach the cli commands from all [rats.cli.Container][] instances to the [click.Group][]."""
+        """
+        Attach the cli commands from all [rats.cli.Container][] instances to the [click.Group][].
+
+        Args:
+            group: The [click.Group][] we are attaching our commands to.
+        """
         for container in self._containers:
             container.attach(group)

--- a/rats-apps/src/python/rats/cli/_plugin.py
+++ b/rats-apps/src/python/rats/cli/_plugin.py
@@ -1,13 +1,31 @@
-from typing import cast
-
 import click
-
-from rats import apps
 
 from ._container import Container
 
 
 def create_group(group: click.Group, container: Container) -> click.Group:
+    """
+    A simple shortcut to create a [click.Group][] with commands provided by `rats.cli.Container`'s.
+
+    ```python
+    import click
+    from rats import cli
+
+
+    class Example(cli.Container):
+        @cli.command()
+        def my_command(self) -> None:
+            print("hello, world. run me with `my-cli my-command`.")
+
+
+    if __name__ == "__main__":
+        cli.create_group(click.Group("my-cli"), Example()).main()
+    ```
+
+    Args:
+        group: The [click.Group][] commands will be added to.
+        container: The [rats.cli.Container][] instance to attach commands from
+    """
     container.attach(group)
     return group
 
@@ -17,27 +35,27 @@ def attach(
     command: click.Command | click.Group,
     *commands: click.Command | click.Group,
 ) -> None:
+    """
+    Convenience function to attach multiple [click.Command]'s to a [click.Group].
+
+    ```python
+    import click
+    from rats import cli
+
+    cli.attach(
+        click.Group("my-cli"),
+        click.Command("command-1"),
+        click.Command("command-2"),
+    )
+    ```
+
+    Args:
+        group: The [click.Group] we want to build.
+        command: A [click.Command] to attach to the provided group.
+        *commands: Any number of additional [click.Command]'s to attach.
+
+    Returns: The input [click.Group][] with all of the commands attached.
+    """
     group.add_command(command)
     for c in commands:
         group.add_command(c)
-
-
-@apps.autoscope
-class _PluginEvents:
-    pass
-
-
-@apps.autoscope
-class PluginServices:
-    EVENTS = _PluginEvents
-
-    @staticmethod
-    def sub_command(
-        parent: apps.ServiceId[apps.Executable],
-        name: str,
-    ) -> apps.ServiceId[apps.Executable]:
-        return apps.ServiceId(f"{parent.name}[{name}]")
-
-    @staticmethod
-    def click_command(cmd_id: apps.ServiceId[apps.Executable]) -> apps.ServiceId[click.Group]:
-        return cast(apps.ServiceId[click.Group], cmd_id)

--- a/rats-devtools/.idea/rats-devtools.iml
+++ b/rats-devtools/.idea/rats-devtools.iml
@@ -10,7 +10,6 @@
     </content>
     <orderEntry type="jdk" jdkName="Poetry (rats-devtools)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="rats-pipelines" />
     <orderEntry type="module" module-name="rats-apps" />
   </component>
   <component name="PackageRequirementsSettings">

--- a/rats-devtools/mkdocs.yaml
+++ b/rats-devtools/mkdocs.yaml
@@ -82,6 +82,7 @@ plugins:
             annotations_path: source
           import:
             - "https://docs.python.org/3/objects.inv"
+            - "https://click.palletsprojects.com/en/stable/objects.inv"
   - awesome-pages
   - mkdocs-video:
       is_video: true

--- a/rats-devtools/pyproject.toml
+++ b/rats-devtools/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "rats-devtools"
 description = "Rats Development Tools"
-version = "0.5.1"
+version = "0.6.0"
 readme = "README.md"
 authors = []
 packages = [

--- a/rats-devtools/src/python/rats/projects/_plugin.py
+++ b/rats-devtools/src/python/rats/projects/_plugin.py
@@ -65,7 +65,7 @@ class PluginContainer(apps.Container, apps.PluginMixin):
             image_push_on_build=bool(os.environ.get("DEVTOOLS_IMAGE_PUSH_ON_BUILD", True)),
             # default tag gets calculated from the project hash
             # but this env can be provided by ci pipelines to control the output version
-            image_tag=os.environ.get("DEVTOOLS_IMAGE_TAG")
+            image_tag=os.environ.get("DEVTOOLS_IMAGE_TAG"),
         )
 
 

--- a/rats-devtools/src/python/rats/projects/_plugin.py
+++ b/rats-devtools/src/python/rats/projects/_plugin.py
@@ -63,6 +63,9 @@ class PluginContainer(apps.Container, apps.PluginMixin):
             path=repo_root,
             image_registry=os.environ.get("DEVTOOLS_IMAGE_REGISTRY", "default.local"),
             image_push_on_build=bool(os.environ.get("DEVTOOLS_IMAGE_PUSH_ON_BUILD", True)),
+            # default tag gets calculated from the project hash
+            # but this env can be provided by ci pipelines to control the output version
+            image_tag=os.environ.get("DEVTOOLS_IMAGE_TAG")
         )
 
 

--- a/rats/pyproject.toml
+++ b/rats/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "rats"
 description = "Package for the bundled rats components."
-version = "0.5.1"
+version = "0.6.0"
 readme = "README.md"
 authors = []
 packages = [{ include = "rats", from = "src/python" }]


### PR DESCRIPTION
- spent a little time filling out the `rats.cli` api docs, removing some unused things, and cleaning up the rendering of things.
- added the ability to link to references of the click documentation.
- added a quick `DEVTOOLS_IMAGE_TAG` environment variable that can be used to specify a version of the devtools image to use instead of the project hash. This is so CI pipelines can specify a version when running `rats-devtools ci build-image`.