### PR TITLE
github releases from ci

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 permissions:
-  contents: read
+  contents: write
   actions: read
   id-token: write
   pages: write

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,3 +46,4 @@ jobs:
       sha: ${{ github.sha }}
       publish-docs: true
       publish-wheels: true
+      publish-to-github: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,4 +44,4 @@ jobs:
       sha: ${{ github.sha }}
       publish-docs: false
       publish-wheels: false
-      publish-to-github: false
+      publish-to-github: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ main ]
 permissions:
-  contents: read
+  contents: write
   actions: read
   id-token: write
   pages: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,4 +44,4 @@ jobs:
       sha: ${{ github.sha }}
       publish-docs: false
       publish-wheels: false
-      publish-to-github: true
+      publish-to-github: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,3 +44,4 @@ jobs:
       sha: ${{ github.sha }}
       publish-docs: false
       publish-wheels: false
+      publish-to-github: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET: ${{ github.sha }}
         run: |
-          gh release create "$PACKAGE_VERSION" \
+          gh release create "v${PACKAGE_VERSION}" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$TARGET" \
             --title "$PACKAGE_VERSION" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,10 @@ on:
         description: 'whether to publish wheels to the configured feed'
         required: true
         type: boolean
+      publish-to-github:
+        description: 'whether to create a github release'
+        required: true
+        type: boolean
 jobs:
   publish-wheels:
     name: "publish-wheels"
@@ -41,6 +45,21 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+  publish-to-github:
+    name: "publish-to-github"
+    runs-on: "ubuntu-latest"
+    if: "${{ inputs.publish-to-github }}"
+    steps:
+      - name: "create-release"
+        env:
+          PACKAGE_VERSION: "${{ steps.runner-context.outputs.package-version }}"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$PACKAGE_VERSION" \
+            --draft \
+            --generate-notes
   publish-docs:
     name: "deploy-docs"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,9 +54,11 @@ jobs:
         env:
           PACKAGE_VERSION: "${{ steps.runner-context.outputs.package-version }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ github.sha }}
         run: |
           gh release create "$tag" \
             --repo "$GITHUB_REPOSITORY" \
+            --target "$TARGET" \
             --title "$PACKAGE_VERSION" \
             --draft \
             --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET: ${{ github.sha }}
         run: |
-          gh release create "$tag" \
+          gh release create "$PACKAGE_VERSION" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$TARGET" \
             --title "$PACKAGE_VERSION" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,11 @@ jobs:
     runs-on: "ubuntu-latest"
     if: "${{ inputs.publish-to-github }}"
     steps:
+      - uses: ./.github/actions/setup-environment
+        id: runner-context
+        with:
+          install-poetry: false
+          install-devtools: false
       - name: "create-release"
         env:
           PACKAGE_VERSION: "${{ steps.runner-context.outputs.package-version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,14 +64,27 @@ jobs:
         env:
           PACKAGE_VERSION: "${{ steps.runner-context.outputs.package-version }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_REF: "${{ github.head_ref || github.ref_name }}"
           TARGET: ${{ github.sha }}
         run: |
-          gh release create "v${PACKAGE_VERSION}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$TARGET" \
-            --title "$PACKAGE_VERSION" \
-            --draft \
-            --generate-notes
+          if  [[ $COMMIT_REF == "v${PACKAGE_VERSION}" ]] ;
+          then
+            echo "detected tag build: $COMMIT_REF"
+            gh release create "v${PACKAGE_VERSION}" \
+              --target "$TARGET" \
+              --title "$PACKAGE_VERSION" \
+              --draft \
+              --generate-notes
+          else
+            echo "detected main branch build"
+            echo "will generate a pre-release"
+            gh release create "v${PACKAGE_VERSION}" \
+              --target "$TARGET" \
+              --title "$PACKAGE_VERSION" \
+              --draft \
+              --prerelease \
+              --generate-notes
+          fi
   publish-docs:
     name: "deploy-docs"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,11 @@ jobs:
     runs-on: "ubuntu-latest"
     if: "${{ inputs.publish-to-github }}"
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+          fetch-tags: true
       - uses: ./.github/actions/setup-environment
         id: runner-context
         with:


### PR DESCRIPTION
this change adds a step to the release ci workflow that generates a github release draft that can be published when we tag a release. it only generates this release on main branch builds and tags, but the main branch builds are marked as `--prerelease`. since they are drafts, they're only visible to contributors until one of us publishes it, at least for now. i think in the future we could make tagged releases publish since that matches the behavior for publishing wheels.

you can see a draft release generated by this pr before disabling pr releases here: https://github.com/microsoft/rats/releases/tag/untagged-1f584fa16e62c912c920

![image](https://github.com/user-attachments/assets/2b2c30b7-783f-4e9b-a696-66102705c095)

refs #119 
