### PR TITLE
remove permissions from pr builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ main ]
 permissions:
-  contents: write
+  contents: read
   actions: read
   id-token: write
   pages: write


### PR DESCRIPTION
this is no longer necessary once we've switched to only creating draft releases from the main branch builds.