### PR TITLE
improve rats.aml experience

### DIFF
--- a/rats-apps/src/rats/app_context/__init__.py
+++ b/rats-apps/src/rats/app_context/__init__.py
@@ -1,6 +1,7 @@
 """Application context package to help share [apps.Container][] state across machines."""
 
 from ._collection import (
+    EMPTY_COLLECTION,
     Collection,
     dumps,
     loads,
@@ -9,6 +10,7 @@ from ._container import GroupContainer, ServiceContainer
 from ._context import Context, T_ContextType
 
 __all__ = [
+    "EMPTY_COLLECTION",
     "Collection",
     "Context",
     "GroupContainer",

--- a/rats-apps/src/rats/app_context/_collection.py
+++ b/rats-apps/src/rats/app_context/_collection.py
@@ -74,6 +74,10 @@ class Collection(Generic[T_ContextType]):
         )
 
 
+EMPTY_COLLECTION = Collection.empty()
+"""Empty collection constant usable as default method values."""
+
+
 def loads(context: str) -> Collection[Any]:
     """
     Transforms a json string into a [rats.app_context.Collection][] instance.

--- a/rats-apps/src/rats/app_context/_collection.py
+++ b/rats-apps/src/rats/app_context/_collection.py
@@ -74,7 +74,7 @@ class Collection(Generic[T_ContextType]):
         )
 
 
-EMPTY_COLLECTION = Collection.empty()
+EMPTY_COLLECTION = Collection[Any].empty()
 """Empty collection constant usable as default method values."""
 
 

--- a/rats-devtools/Containerfile
+++ b/rats-devtools/Containerfile
@@ -36,25 +36,27 @@ COPY rats-apps /opt/rats/rats-apps
 RUN <<HEREDOC
 # create skeleton of python packages
 set -eux
-mkdir -p /opt/rats/rats-devtools/src/python/rats/amlruntime
-mkdir -p /opt/rats/rats-devtools/src/python/rats/ci
-mkdir -p /opt/rats/rats-devtools/src/python/rats/command_tree
-mkdir -p /opt/rats/rats-devtools/src/python/rats/devtools
-mkdir -p /opt/rats/rats-devtools/src/python/rats/docs
-mkdir -p /opt/rats/rats-devtools/src/python/rats/example
-mkdir -p /opt/rats/rats-devtools/src/python/rats/kuberuntime
-mkdir -p /opt/rats/rats-devtools/src/python/rats/stdruntime
-mkdir -p /opt/rats/rats-devtools/src/python/rats/projects
+mkdir -p /opt/rats/rats-devtools/src/rats/aml
+mkdir -p /opt/rats/rats-devtools/src/rats/amlruntime
+mkdir -p /opt/rats/rats-devtools/src/rats/ci
+mkdir -p /opt/rats/rats-devtools/src/rats/command_tree
+mkdir -p /opt/rats/rats-devtools/src/rats/docs
+mkdir -p /opt/rats/rats-devtools/src/rats/ez
+mkdir -p /opt/rats/rats-devtools/src/rats/projects
 
-touch /opt/rats/rats-devtools/src/python/rats/amlruntime/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/ci/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/command_tree/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/devtools/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/docs/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/example/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/kuberuntime/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/stdruntime/__init__.py
-touch /opt/rats/rats-devtools/src/python/rats/projects/__init__.py
+mkdir -p /opt/rats/rats-devtools/src/rats_e2e/aml
+mkdir -p /opt/rats/rats-devtools/src/rats_resources/docs
+
+touch /opt/rats/rats-devtools/src/rats/aml/__init__.py
+touch /opt/rats/rats-devtools/src/rats/amlruntime/__init__.py
+touch /opt/rats/rats-devtools/src/rats/ci/__init__.py
+touch /opt/rats/rats-devtools/src/rats/command_tree/__init__.py
+touch /opt/rats/rats-devtools/src/rats/docs/__init__.py
+touch /opt/rats/rats-devtools/src/rats/ez/__init__.py
+touch /opt/rats/rats-devtools/src/rats/projects/__init__.py
+
+touch /opt/rats/rats-devtools/src/rats_e2e/aml/__init__.py
+touch /opt/rats/rats-devtools/src/rats_resources/docs/__init__.py
 
 HEREDOC
 

--- a/rats-devtools/pyproject.toml
+++ b/rats-devtools/pyproject.toml
@@ -61,7 +61,7 @@ rats-docs = "rats.docs:main"
 rats-ez = "rats.ez:main"
 rats-aml = "rats.aml:main"
 
-[project.entry-points."rats.aml"]
+[project.entry-points."rats.aml.apps"]
 "rats_e2e.aml.hello-world" = "rats_e2e.aml:Application"
 
 [build-system]

--- a/rats-devtools/src/rats/aml/__init__.py
+++ b/rats-devtools/src/rats/aml/__init__.py
@@ -1,6 +1,6 @@
 """Submit applications as aml jobs, sending necessary context from the driver node."""
 
-from ._app import AppConfigs, Application, AppServices, main
+from ._app import AppConfigs, Application, AppServices, main, submit
 from ._configs import AmlEnvironment, AmlIO, AmlJobContext, AmlJobDetails, AmlWorkspace
 
 __all__ = [
@@ -13,4 +13,5 @@ __all__ = [
     "AppServices",
     "Application",
     "main",
+    "submit",
 ]

--- a/rats-devtools/src/rats/aml/_app.py
+++ b/rats-devtools/src/rats/aml/_app.py
@@ -292,9 +292,6 @@ class Application(apps.AppContainer, cli.Container, apps.PluginMixin):
         if len(app_ids) == 0:
             logging.warning("No applications were provided to the command")
 
-        ptools = self._app.get(projects.PluginServices.PROJECT_TOOLS)
-        ptools.build_component_image(Path.cwd().name)
-
         ctx = app_context.loads(context).add(
             *self._app.get_group(AppConfigs.APP_CONTEXT),
         )

--- a/rats-devtools/src/rats/aml/_app.py
+++ b/rats-devtools/src/rats/aml/_app.py
@@ -539,7 +539,7 @@ class Application(apps.AppContainer, cli.Container, apps.PluginMixin):
 
 
 def submit(
-    *app_ids: tuple[str, ...],
+    *app_ids: str,
     context: app_context.Collection[Any] = app_context.EMPTY_COLLECTION,
     wait: bool = False,
 ) -> None:


### PR DESCRIPTION
some follow up refactoring based on our experience trying the first version of this

- no longer building the container image automatically before submitting the aml job. the user now is expected to run `rats-ci build-image` before calling `rats-aml submit`.
- adding `rats.aml.submit()` as a way to submit job through code instead of using the cli
- no longer allowing click to exit the process after the first execution of our aml app, allowing multiple calls within a process.
- validating the name of the apps being submitted on the host before creating an aml job.
- switched the entry-point group used for registering runnable apps, avoiding conflicts with the app plugins used on in `rats.aml.Application`.