### PR TITLE
app less bundles

### DIFF
--- a/rats-apps/pyproject.toml
+++ b/rats-apps/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rats-apps"
 description = "research analysis tools for building applications"
-version = "0.10.1"
+version = "0.10.2"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/rats-apps/src/rats/apps/__init__.py
+++ b/rats-apps/src/rats/apps/__init__.py
@@ -16,6 +16,7 @@ from ._annotations import (
     service,
 )
 from ._app_containers import (
+    EMPTY_APP_PLUGIN,
     EMPTY_PLUGIN,
     AppBundle,
     AppContainer,
@@ -23,6 +24,7 @@ from ._app_containers import (
     CompositePlugin,
     ContainerPlugin,
     PluginMixin,
+    bundle,
 )
 from ._composite_container import EMPTY_CONTAINER, CompositeContainer
 from ._container import (
@@ -43,6 +45,7 @@ from ._scoping import autoscope
 from ._static_container import StaticContainer, StaticProvider, static_group, static_service
 
 __all__ = [
+    "EMPTY_APP_PLUGIN",
     "EMPTY_CONTAINER",
     "EMPTY_PLUGIN",
     "App",
@@ -73,6 +76,7 @@ __all__ = [
     "autoid_factory_service",
     "autoid_service",
     "autoscope",
+    "bundle",
     "container",
     "factory_service",
     "fallback_group",

--- a/rats-apps/src/rats/apps/_app_containers.py
+++ b/rats-apps/src/rats/apps/_app_containers.py
@@ -198,3 +198,41 @@ class AppBundle(AppContainer):
     @cache  # noqa: B019
     def _get_or_create_containers(self) -> tuple[AppContainer, Container]:
         return self._app_plugin(self), self._container_plugin(self)
+
+
+class _EmptyAppContainer(AppContainer, PluginMixin):
+    pass
+
+
+EMPTY_APP_PLUGIN = _EmptyAppContainer
+
+
+def bundle(
+    *container_plugins: ContainerPlugin,
+    context: Container = EMPTY_CONTEXT,
+) -> Container:
+    """
+    Create an instance of a plugin container, without the need to create an application.
+
+    Example:
+        ```python
+        from rats import apps, projects
+
+
+        def main() -> None:
+            apps.bundle(projects.PluginContainer)
+
+
+        if __name__ == "__main__":
+            main()
+        ```
+
+    Args:
+        container_plugins: one or more plugins that will be initialized with an empty application.
+        context: additional context made available to the container plugins.
+    """
+    return AppBundle(
+        app_plugin=EMPTY_APP_PLUGIN,
+        container_plugin=CompositePlugin(*container_plugins),
+        context=context,
+    )

--- a/rats-devtools/pyproject.toml
+++ b/rats-devtools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rats-devtools"
 description = "Rats Development Tools"
-version = "0.10.1"
+version = "0.10.2"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/rats-devtools/src/rats/aml/_app.py
+++ b/rats-devtools/src/rats/aml/_app.py
@@ -178,13 +178,16 @@ class AppConfigs:
     `RATS_AML_PATH_MODEL_INPUT` containing the local path to the mounted directory/file.
 
     ```python
-    class Plugin(apps.Container):
-        @apps.fallback_group(AppConfigs.INPUTS)
+    from rats import apps, aml
+
+
+    class PluginContainer(apps.Container):
+        @apps.group(aml.AppConfigs.INPUTS)
         def _inputs(self) -> Iterator[Mapping[str, AmlIO]]:
             from azure.ai.ml.constants import AssetTypes, InputOutputModes
 
             yield {
-                f"[input-name]": AmlIO(
+                f"[input-name]": aml.AmlIO(
                     type=AssetTypes.URI_FOLDER,
                     path=f"abfss://[container]@[storage-account].dfs.core.windows.net/[path]",
                     mode=InputOutputModes.RW_MOUNT,
@@ -202,13 +205,16 @@ class AppConfigs:
     `RATS_AML_PATH_MODEL_OUTPUT` containing the local path to the mounted directory/file.
 
     ```python
-    class Plugin(apps.Container):
-        @apps.fallback_group(AppConfigs.OUTPUTS)
-        def _outputs(self) -> Iterator[Mapping[str, AmlIO]]:
+    from rats import apps, aml
+
+
+    class PluginContainer(apps.Container):
+        @apps.group(aml.AppConfigs.OUTPUTS)
+        def _outputs(self) -> Iterator[Mapping[str, aml.AmlIO]]:
             from azure.ai.ml.constants import AssetTypes, InputOutputModes
 
             yield {
-                f"[output-name]": AmlIO(
+                f"[output-name]": aml.AmlIO(
                     type=AssetTypes.URI_FOLDER,
                     path=f"abfss://[container]@[storage-account].dfs.core.windows.net/[path]",
                     mode=InputOutputModes.RW_MOUNT,
@@ -225,6 +231,9 @@ class AppConfigs:
     retrieve this service config on the aml job instance to retrieve the registered contexts.
 
     ```python
+    from rats import apps, aml
+
+
     class Application(apps.AppContainer):
         def execute(self) -> None:
             context_collection = self._app.get(aml.AppConfigs.CONTEXT_COLLECTION)
@@ -242,9 +251,12 @@ class AppConfigs:
     definition of these service groups.
 
     ```python
+    from rats import apps, aml
+
+
     class Plugin(apps.Container):
 
-        @apps.service_group(AppConfigs.CLI_ENVS)
+        @apps.service_group(aml.AppConfigs.CLI_ENVS)
         def _envs(self) -> Iterator[Mapping[str, str]]:
             yield {"MY_JOB_ENV": "some-useful-information"}
     ```

--- a/rats/pyproject.toml
+++ b/rats/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rats"
 description = "bundled research analysis tools"
-version = "0.10.1"
+version = "0.10.2"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [


### PR DESCRIPTION
adding a couple small convenience shortcuts to `rats.apps` along with a few minor docs changes.

- `rats.apps.EMPTY_APP_PLUGIN` can be used anywhere an app plugin is needed, and will simply log a warning if we ever execute this app
- `rats.apps.bundle` lets you create instances of plugin containers without needing to implement an application. you might do this for things like `rats.projects.PluginContainer` which have no real dependencies and provide access to shared services like the project tools.