### PR TITLE
rats.logs docs and configs

### DIFF
--- a/rats-apps/src/rats/logs/__init__.py
+++ b/rats-apps/src/rats/logs/__init__.py
@@ -1,7 +1,22 @@
-"""Small package to help configure logging for rats applications."""
+"""
+Small module to help configure logging for rats applications.
 
-from ._app import ConfigureApplication
+We provide a rats application that can be executed at the beginning of your process, that will
+handle configuring the python logging libraries, with a few configuration options being exposed.
+
+!!! warning
+    We expose the logging functionality through a [rats.apps.AppContainer][] in order to leverage
+    the built in plugin system to give users the ability to adjust the default settings, but this
+    entire application should be lightweight and should not contain very complex logic, avoiding
+    logic that is very time consuming or has a chance of failing with confusing errors.
+
+    If the logging options made available through this module are far from what is desired, instead
+    of adding flags and options to this module, we recommend configuring logging in your own code.
+"""
+
+from ._app import AppConfigs, ConfigureApplication
 
 __all__ = [
+    "AppConfigs",
     "ConfigureApplication",
 ]

--- a/rats-apps/src/rats/logs/_app.py
+++ b/rats-apps/src/rats/logs/_app.py
@@ -1,13 +1,58 @@
 import logging.config
 import warnings
+from collections.abc import Iterator
+from typing import Any
 
 from rats import apps
 
 logger = logging.getLogger(__name__)
+LoggerConfigEntry = tuple[str, dict[str, Any]]
+
+
+@apps.autoscope
+class AppConfigs:
+    LOGGERS = apps.ServiceId[LoggerConfigEntry]("loggers.config-group")
+    """
+    Register additional loggers to this service group.
+
+    ```python
+    from rats import apps
+
+
+    class PluginContainer(apps.Container, apps.PluginMixin):
+        @apps.group(AppConfigs.LOGGERS)
+        def _custom_loggers(self) -> Iterator[LoggerConfigEntry]:
+            yield "", {"level": "INFO", "handlers": ["console"]}
+            yield "azure", {"level": "WARNING", "handlers": ["console"]}
+
+
+    # provide the new configuration when executing `logs.ConfigureApplcation`
+    apps.run(apps.AppBundle(
+        app_plugin=logs.ConfigureApplication,
+        container_plugin=PluginContainer,
+    ))
+    ```
+    """
 
 
 class ConfigureApplication(apps.AppContainer, apps.PluginMixin):
+    """
+    Configure logging for the current process.
+
+    We try to provide some simple default loggers, but you can replace the loggers by providing the
+    [rats.logs.AppConfigs.LOGGERS][] service group.
+
+    ```python
+    from rats import apps, logs
+
+    apps.run(apps.AppBundle(app_plugin=logs.ConfigureApplication))
+    ```
+    """
+
     def execute(self) -> None:
+        """Logging should be configured after the execution of this application."""
+        logger_configs = self._app.get_group(AppConfigs.LOGGERS)
+        loggers_dict = {key: value for key, value in logger_configs}
         logging.config.dictConfig(
             {
                 "version": 1,
@@ -37,13 +82,15 @@ class ConfigureApplication(apps.AppContainer, apps.PluginMixin):
                         "stream": "ext://sys.stderr",
                     }
                 },
-                "loggers": {
-                    "": {"level": "INFO", "handlers": ["console"]},
-                    "azure": {"level": "WARNING", "handlers": ["console"]},
-                },
+                "loggers": loggers_dict,
             }
         )
         # enable deprecation warnings by default
         logging.captureWarnings(True)
         warnings.simplefilter("default", DeprecationWarning)
         logger.debug("done configuring logging")
+
+    @apps.fallback_group(AppConfigs.LOGGERS)
+    def _default_loggers(self) -> Iterator[LoggerConfigEntry]:
+        yield "", {"level": "INFO", "handlers": ["console"]}
+        yield "azure", {"level": "WARNING", "handlers": ["console"]}

--- a/rats-apps/src/rats/logs/_app.py
+++ b/rats-apps/src/rats/logs/_app.py
@@ -50,7 +50,7 @@ class ConfigureApplication(apps.AppContainer, apps.PluginMixin):
     """
 
     def execute(self) -> None:
-        """Logging should be configured after the execution of this application."""
+        """Applies the logging configuration."""
         logger_configs = self._app.get_group(AppConfigs.LOGGERS)
         loggers_dict = {key: value for key, value in logger_configs}
         logging.config.dictConfig(

--- a/rats-apps/src/rats/logs/_app.py
+++ b/rats-apps/src/rats/logs/_app.py
@@ -1,4 +1,5 @@
 import logging.config
+import warnings
 
 from rats import apps
 
@@ -42,4 +43,7 @@ class ConfigureApplication(apps.AppContainer, apps.PluginMixin):
                 },
             }
         )
+        # enable deprecation warnings by default
+        logging.captureWarnings(True)
+        warnings.simplefilter("default", DeprecationWarning)
         logger.debug("done configuring logging")

--- a/rats-apps/src/rats/logs/_app.py
+++ b/rats-apps/src/rats/logs/_app.py
@@ -26,7 +26,7 @@ class AppConfigs:
             yield "azure", {"level": "WARNING", "handlers": ["console"]}
 
 
-    # provide the new configuration when executing `logs.ConfigureApplcation`
+    # provide the new configuration when executing `logs.ConfigureAppilcation`
     apps.run(apps.AppBundle(
         app_plugin=logs.ConfigureApplication,
         container_plugin=PluginContainer,


### PR DESCRIPTION
trying to get the `rats.logs` module to a decent enough state so we aren't constantly replacing it in every project. we have some basic documentation, and a tiny config to set `rats.logs.AppConfigs.LOGGERS` with your preferred logger specific settings.

also logging deprecation warnings now.

#522 