### PR TITLE
use the docs home page as the readme for our 3 packages

### DIFF
--- a/rats-apps/README.md
+++ b/rats-apps/README.md
@@ -1,2 +1,1 @@
-# rats-apps
-...
+docs/index.md

--- a/rats-devtools/README.md
+++ b/rats-devtools/README.md
@@ -1,2 +1,1 @@
-# rats-devtools
-...
+docs/index.md

--- a/rats/README.md
+++ b/rats/README.md
@@ -1,2 +1,1 @@
-# rats
-...
+docs/index.md


### PR DESCRIPTION
this fixes our pypi pages being empty and instead uses the matching `docs/index.md` file as the package readme

refs #484 