### PR TITLE
add the glightbox mkdocs plugin for nicer documentation images

### DIFF
--- a/rats-devtools/mkdocs.yaml
+++ b/rats-devtools/mkdocs.yaml
@@ -92,6 +92,7 @@ plugins:
   - mkdocs-video:
       is_video: true
       video_controls: true
+  - glightbox
 markdown_extensions:
   # Allows for nicely styled notes and warnings: !!! note
   - admonition

--- a/rats-devtools/poetry.lock
+++ b/rats-devtools/poetry.lock
@@ -1486,6 +1486,18 @@ platformdirs = ">=2.2.0"
 pyyaml = ">=5.1"
 
 [[package]]
+name = "mkdocs-glightbox"
+version = "0.4.0"
+description = "MkDocs plugin supports image lightbox with GLightbox."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "mkdocs-glightbox-0.4.0.tar.gz", hash = "sha256:392b34207bf95991071a16d5f8916d1d2f2cd5d5bb59ae2997485ccd778c70d9"},
+    {file = "mkdocs_glightbox-0.4.0-py3-none-any.whl", hash = "sha256:e0107beee75d3eb7380ac06ea2d6eac94c999eaa49f8c3cbab0e7be2ac006ccf"},
+]
+
+[[package]]
 name = "mkdocs-material"
 version = "9.6.14"
 description = "Documentation that simply works"
@@ -3083,4 +3095,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "bb1deaab7e56faebcb3f205e14fccbf6185016975941a1762107cf31b6a44513"
+content-hash = "089d5de10077bbd8575f00e7a5c291ce823a3d6dee613aca3d147a51e6393d83"

--- a/rats-devtools/pyproject.toml
+++ b/rats-devtools/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "mkdocs-awesome-pages-plugin",
     "mkdocs-material",
     "mkdocs-video",
+    "mkdocs-glightbox",
     "mdx-truly-sane-lists",
     "mkdocstrings",
     "mkdocstrings-python",


### PR DESCRIPTION
we don't have any images in our docs right now but this allows us to add images that can be easily viewed on smaller screens