### PR TITLE
fix docs rough edges (#492) and remove deprecated docs code

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -28,7 +28,7 @@ jobs:
           cd rats-devtools
           poetry version "$PACKAGE_VERSION"
           rats-ci install
-          rats-docs mkdocs-build
+          rats-docs build
       - name: "upload-gh-pages"
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/rats
+++ b/docs/rats
@@ -1,0 +1,1 @@
+../rats/docs

--- a/docs/rats-apps
+++ b/docs/rats-apps
@@ -1,0 +1,1 @@
+../rats-apps/docs

--- a/docs/rats-devtools
+++ b/docs/rats-devtools
@@ -1,0 +1,1 @@
+../rats-devtools/docs

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -54,9 +54,8 @@ extra_css:
 #  - js/mathjax.js
 #  - js/tex-mml-chtml.js
 watch:
-  - "../../rats-apps/src"
-  - "../../rats-devtools/src"
-  - "../../rats-devtools/mkdocs.yaml"
+  - rats-apps/src
+  - rats-devtools/src
 plugins:
   - search
   - mkdocstrings:
@@ -64,12 +63,10 @@ plugins:
       handlers:
         python:
           paths:
-            # we don't need to install packages to generate docs any more
-            # these paths should be relative from rats-devtools/dist
-            # we can automate the detection of this list later
-            - "../../rats/src"
-            - "../../rats-apps/src"
-            - "../../rats-devtools/src"
+            # these paths should be relative from repo root
+            - rats/src
+            - rats-apps/src
+            - rats-devtools/src
           options:
             show_if_no_docstring: true
             show_symbol_type_toc: true
@@ -109,10 +106,14 @@ markdown_extensions:
       # add paths relative to the devtools component here if you want to include them using -8<-
       # https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#snippets-notation
       base_path:
-        - "../"  # let us use full paths from the repo root
+        # always allow us to embed file paths from the root of the repo
+        - !relative $config_dir
         # or relative from each src directory
-        - "../rats-apps/src"
-        - "../rats-devtools/src"
+        - !relative $config_dir/rats-apps/src
+        - !relative $config_dir/rats-devtools/src
+        # or test directory
+        - !relative $config_dir/rats-apps/test
+        - !relative $config_dir/rats-devtools/test
       # fail the mkdocs build if any snippets link to missing files
       # this delays painful bugs being found when disabled
       check_paths: true

--- a/rats-apps/poetry.lock
+++ b/rats-apps/poetry.lock
@@ -405,30 +405,30 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.12.0"
+version = "0.12.1"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.12.0-py3-none-linux_armv6l.whl", hash = "sha256:5652a9ecdb308a1754d96a68827755f28d5dfb416b06f60fd9e13f26191a8848"},
-    {file = "ruff-0.12.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:05ed0c914fabc602fc1f3b42c53aa219e5736cb030cdd85640c32dbc73da74a6"},
-    {file = "ruff-0.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:07a7aa9b69ac3fcfda3c507916d5d1bca10821fe3797d46bad10f2c6de1edda0"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7731c3eec50af71597243bace7ec6104616ca56dda2b99c89935fe926bdcd48"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:952d0630eae628250ab1c70a7fffb641b03e6b4a2d3f3ec6c1d19b4ab6c6c807"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c021f04ea06966b02614d442e94071781c424ab8e02ec7af2f037b4c1e01cc82"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d235618283718ee2fe14db07f954f9b2423700919dc688eacf3f8797a11315c"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0c0758038f81beec8cc52ca22de9685b8ae7f7cc18c013ec2050012862cc9165"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:139b3d28027987b78fc8d6cfb61165447bdf3740e650b7c480744873688808c2"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68853e8517b17bba004152aebd9dd77d5213e503a5f2789395b25f26acac0da4"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3a9512af224b9ac4757f7010843771da6b2b0935a9e5e76bb407caa901a1a514"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b08df3d96db798e5beb488d4df03011874aff919a97dcc2dd8539bb2be5d6a88"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a315992297a7435a66259073681bb0d8647a826b7a6de45c6934b2ca3a9ed51"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e55e44e770e061f55a7dbc6e9aed47feea07731d809a3710feda2262d2d4d8a"},
-    {file = "ruff-0.12.0-py3-none-win32.whl", hash = "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb"},
-    {file = "ruff-0.12.0-py3-none-win_amd64.whl", hash = "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0"},
-    {file = "ruff-0.12.0-py3-none-win_arm64.whl", hash = "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b"},
-    {file = "ruff-0.12.0.tar.gz", hash = "sha256:4d047db3662418d4a848a3fdbfaf17488b34b62f527ed6f10cb8afd78135bc5c"},
+    {file = "ruff-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:6013a46d865111e2edb71ad692fbb8262e6c172587a57c0669332a449384a36b"},
+    {file = "ruff-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3f75a19e03a4b0757d1412edb7f27cffb0c700365e9d6b60bc1b68d35bc89e0"},
+    {file = "ruff-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a256522893cb7e92bb1e1153283927f842dea2e48619c803243dccc8437b8be"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:069052605fe74c765a5b4272eb89880e0ff7a31e6c0dbf8767203c1fbd31c7ff"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a684f125a4fec2d5a6501a466be3841113ba6847827be4573fddf8308b83477d"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdecdef753bf1e95797593007569d8e1697a54fca843d78f6862f7dc279e23bd"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:70d52a058c0e7b88b602f575d23596e89bd7d8196437a4148381a3f73fcd5010"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84d0a69d1e8d716dfeab22d8d5e7c786b73f2106429a933cee51d7b09f861d4e"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cc32e863adcf9e71690248607ccdf25252eeeab5193768e6873b901fd441fed"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd49a4619f90d5afc65cf42e07b6ae98bb454fd5029d03b306bd9e2273d44cc"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ed5af6aaaea20710e77698e2055b9ff9b3494891e1b24d26c07055459bb717e9"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801d626de15e6bf988fbe7ce59b303a914ff9c616d5866f8c79eb5012720ae13"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2be9d32a147f98a1972c1e4df9a6956d612ca5f5578536814372113d09a27a6c"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49b7ce354eed2a322fbaea80168c902de9504e6e174fd501e9447cad0232f9e6"},
+    {file = "ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245"},
+    {file = "ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013"},
+    {file = "ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc"},
+    {file = "ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c"},
 ]
 
 [[package]]

--- a/rats-apps/pyproject.toml
+++ b/rats-apps/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rats-apps"
 description = "research analysis tools for building applications"
-version = "0.12.0"
+version = "0.13.0"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/rats-devtools/poetry.lock
+++ b/rats-devtools/poetry.lock
@@ -186,14 +186,14 @@ opentelemetry-sdk = ">=1.28.0,<1.32"
 
 [[package]]
 name = "azure-monitor-opentelemetry-exporter"
-version = "1.0.0b38"
+version = "1.0.0b39"
 description = "Microsoft Azure Monitor Opentelemetry Exporter Client Library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "azure_monitor_opentelemetry_exporter-1.0.0b38-py2.py3-none-any.whl", hash = "sha256:eda37c4f32a3b50d2946efda4e27fc17f216533e152cf1209b96fe9141f8ef0d"},
-    {file = "azure_monitor_opentelemetry_exporter-1.0.0b38.tar.gz", hash = "sha256:cabc0313a06067612a27ca852ff782aa34e726d32e1816cd0366981a8b29b926"},
+    {file = "azure_monitor_opentelemetry_exporter-1.0.0b39-py2.py3-none-any.whl", hash = "sha256:22419084272affeb117e47abd7420a4040ae370ee844c0167ccbc77c26490cc3"},
+    {file = "azure_monitor_opentelemetry_exporter-1.0.0b39.tar.gz", hash = "sha256:c28f5f56261ad40ab69eb00ba4e60d50417ec30e343afccc65c5c89ba4056087"},
 ]
 
 [package.dependencies]
@@ -2367,7 +2367,7 @@ pyyaml = "*"
 
 [[package]]
 name = "rats-apps"
-version = "0.12.0"
+version = "0.13.0"
 description = "research analysis tools for building applications"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2643,30 +2643,30 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.12.0"
+version = "0.12.1"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.12.0-py3-none-linux_armv6l.whl", hash = "sha256:5652a9ecdb308a1754d96a68827755f28d5dfb416b06f60fd9e13f26191a8848"},
-    {file = "ruff-0.12.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:05ed0c914fabc602fc1f3b42c53aa219e5736cb030cdd85640c32dbc73da74a6"},
-    {file = "ruff-0.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:07a7aa9b69ac3fcfda3c507916d5d1bca10821fe3797d46bad10f2c6de1edda0"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7731c3eec50af71597243bace7ec6104616ca56dda2b99c89935fe926bdcd48"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:952d0630eae628250ab1c70a7fffb641b03e6b4a2d3f3ec6c1d19b4ab6c6c807"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c021f04ea06966b02614d442e94071781c424ab8e02ec7af2f037b4c1e01cc82"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7d235618283718ee2fe14db07f954f9b2423700919dc688eacf3f8797a11315c"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0c0758038f81beec8cc52ca22de9685b8ae7f7cc18c013ec2050012862cc9165"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:139b3d28027987b78fc8d6cfb61165447bdf3740e650b7c480744873688808c2"},
-    {file = "ruff-0.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68853e8517b17bba004152aebd9dd77d5213e503a5f2789395b25f26acac0da4"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3a9512af224b9ac4757f7010843771da6b2b0935a9e5e76bb407caa901a1a514"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b08df3d96db798e5beb488d4df03011874aff919a97dcc2dd8539bb2be5d6a88"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a315992297a7435a66259073681bb0d8647a826b7a6de45c6934b2ca3a9ed51"},
-    {file = "ruff-0.12.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e55e44e770e061f55a7dbc6e9aed47feea07731d809a3710feda2262d2d4d8a"},
-    {file = "ruff-0.12.0-py3-none-win32.whl", hash = "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb"},
-    {file = "ruff-0.12.0-py3-none-win_amd64.whl", hash = "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0"},
-    {file = "ruff-0.12.0-py3-none-win_arm64.whl", hash = "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b"},
-    {file = "ruff-0.12.0.tar.gz", hash = "sha256:4d047db3662418d4a848a3fdbfaf17488b34b62f527ed6f10cb8afd78135bc5c"},
+    {file = "ruff-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:6013a46d865111e2edb71ad692fbb8262e6c172587a57c0669332a449384a36b"},
+    {file = "ruff-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3f75a19e03a4b0757d1412edb7f27cffb0c700365e9d6b60bc1b68d35bc89e0"},
+    {file = "ruff-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a256522893cb7e92bb1e1153283927f842dea2e48619c803243dccc8437b8be"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:069052605fe74c765a5b4272eb89880e0ff7a31e6c0dbf8767203c1fbd31c7ff"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a684f125a4fec2d5a6501a466be3841113ba6847827be4573fddf8308b83477d"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdecdef753bf1e95797593007569d8e1697a54fca843d78f6862f7dc279e23bd"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:70d52a058c0e7b88b602f575d23596e89bd7d8196437a4148381a3f73fcd5010"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84d0a69d1e8d716dfeab22d8d5e7c786b73f2106429a933cee51d7b09f861d4e"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cc32e863adcf9e71690248607ccdf25252eeeab5193768e6873b901fd441fed"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd49a4619f90d5afc65cf42e07b6ae98bb454fd5029d03b306bd9e2273d44cc"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ed5af6aaaea20710e77698e2055b9ff9b3494891e1b24d26c07055459bb717e9"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801d626de15e6bf988fbe7ce59b303a914ff9c616d5866f8c79eb5012720ae13"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2be9d32a147f98a1972c1e4df9a6956d612ca5f5578536814372113d09a27a6c"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49b7ce354eed2a322fbaea80168c902de9504e6e174fd501e9447cad0232f9e6"},
+    {file = "ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245"},
+    {file = "ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013"},
+    {file = "ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc"},
+    {file = "ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c"},
 ]
 
 [[package]]

--- a/rats-devtools/pyproject.toml
+++ b/rats-devtools/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rats-devtools"
 description = "Rats Development Tools"
-version = "0.12.0"
+version = "0.13.0"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/rats-devtools/src/rats/docs/__init__.py
+++ b/rats-devtools/src/rats/docs/__init__.py
@@ -9,14 +9,23 @@ We don't plan on enhancing the features of the documentation tooling outside of 
 mkdocs plugins. Teams working in single-component repositories should be able to author
 documentation using the standard `mkdocs build` and `mkdocs serve` commands. In monorepos, our
 tools help enable cross-referencing and generate a single site that allows us to search across all
-components instead of publishing an isolated documentation site for each component.
+components instead of publishing an isolated documentation site for each component. We try to
+accomplish this as a small command proxy that inserts default arguments to the underlying `mkdocs`
+command.
+
+!!! note
+    Previously, this module would copy original markdown files, and symlink directories during the
+    build process to unify the docs across components. However, over time, we've found solutions
+    that eliminate these custom operations, making the `rats-docs` commands much simpler, and
+    making it easy to get the same output when using `mkdocs` commands directly.
 
 ## Structure
 
 We structure our documentation site such that each component is as self contained as possible, each
-containing a dedicated `docs` directories. These component docs are then merged with a `docs`
-folder found at the root of the repository, where authors can create tutorials and other types of
-content that might combine component features to build comprehensive examples.
+containing a dedicated `docs` directory. These component docs are then merged with a `docs` folder
+found at the root of the repository, where authors can create tutorials and other types of content
+that might combine component features to build comprehensive examples. The root docs directory uses
+symlinks to the individual component docs, and `mkdocs` is only made aware of the root docs.
 
 We can look at the structure of the `rats` repo as an example:
 
@@ -69,9 +78,8 @@ We can look at the structure of the `rats` repo as an example:
 
 1.  :man_raising_hand: The root documentation can contain an introduction to the project and
     provide links to component pages.
-2.  :man_raising_hand: Components contain their own `docs` directory. When built, the component
-    documentation gets placed in a directory within the root documentation. The `rats-apps`
-    documentation will be at `/rats-apps/`.
+2.  :man_raising_hand: Components contain their own `docs` directory. We symlink this directory
+    such that the `rats-apps` documentation will be at `/rats-apps/`.
 3.  :man_raising_hand: This page is part of `rats-devtools` and will be built as if it was found
     at `docs/rats-devtools/rats.docs.md`.
 
@@ -110,8 +118,19 @@ INFO    -  [23:06:24] Browser connected: http://127.0.0.1:8000/
 ```
 
 !!! note
-    `rats-docs serve` and `rats-docs build` are simply using the `mkdocs` cli after combining all
-    of the documentation files into a staging directory.
+    `rats-docs serve` and `rats-docs build` are simply using the `mkdocs` cli after, and you can
+    provide arguments to the underlying command separated by a double dash `--`. You can see the
+    entire list of options by running `rats-docs serve -- --help`, which should be equivalent to
+    running `mkdocs serve --help`.
+
+    ```
+    $ rats-docs serve -- --dev-addr "127.0.0.1:8181"
+    INFO    -  Building documentation...
+    INFO    -  Cleaning site directory
+    INFO    -  Documentation built in 2.73 seconds
+    …
+    INFO    -  [14:42:00] Serving on http://127.0.0.1:8181/
+    ```
 
 ## Configuration
 

--- a/rats/poetry.lock
+++ b/rats/poetry.lock
@@ -186,14 +186,14 @@ opentelemetry-sdk = ">=1.28.0,<1.32"
 
 [[package]]
 name = "azure-monitor-opentelemetry-exporter"
-version = "1.0.0b38"
+version = "1.0.0b39"
 description = "Microsoft Azure Monitor Opentelemetry Exporter Client Library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "local"]
 files = [
-    {file = "azure_monitor_opentelemetry_exporter-1.0.0b38-py2.py3-none-any.whl", hash = "sha256:eda37c4f32a3b50d2946efda4e27fc17f216533e152cf1209b96fe9141f8ef0d"},
-    {file = "azure_monitor_opentelemetry_exporter-1.0.0b38.tar.gz", hash = "sha256:cabc0313a06067612a27ca852ff782aa34e726d32e1816cd0366981a8b29b926"},
+    {file = "azure_monitor_opentelemetry_exporter-1.0.0b39-py2.py3-none-any.whl", hash = "sha256:22419084272affeb117e47abd7420a4040ae370ee844c0167ccbc77c26490cc3"},
+    {file = "azure_monitor_opentelemetry_exporter-1.0.0b39.tar.gz", hash = "sha256:c28f5f56261ad40ab69eb00ba4e60d50417ec30e343afccc65c5c89ba4056087"},
 ]
 
 [package.dependencies]
@@ -2141,7 +2141,7 @@ pyyaml = "*"
 
 [[package]]
 name = "rats-apps"
-version = "0.12.0"
+version = "0.13.0"
 description = "research analysis tools for building applications"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2162,7 +2162,7 @@ url = "../rats-apps"
 
 [[package]]
 name = "rats-devtools"
-version = "0.12.0"
+version = "0.13.0"
 description = "Rats Development Tools"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2753,4 +2753,4 @@ devtools = ["rats-devtools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "4a04e8b8f0e7359995ab82240b98080ebcd9b72ba1e153379a7e06e15fa5226e"
+content-hash = "aefe1d29d5a72839b79568ebaf7e679b83c5873b6ebd43124ed3b03c7577e464"

--- a/rats/pyproject.toml
+++ b/rats/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "rats"
 description = "bundled research analysis tools"
-version = "0.12.0"
+version = "0.13.0"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [
@@ -15,10 +15,10 @@ dependencies = []
 
 [project.optional-dependencies]
 apps = [
-    "rats-apps (==0.12.0)",
+    "rats-apps (==0.13.0)",
 ]
 devtools = [
-    "rats-devtools (==0.12.0)",
+    "rats-devtools (==0.13.0)",
 ]
 
 [project.urls]


### PR DESCRIPTION
- the `rats-docs mkdocs-serve` and `rats-docs mkdocs-build` commands are now removed and replaced with `rats-docs serve` and `rats-docs build` respectively.
- our `rats-docs` command does almost nothing now, removing the last remaining rough edges described in #492 and instead using symlinks to unify the docs across components. leaving the command in the code because of a possible future where we can generate the scaffolding for people trying to first set up documentation in their repo.
- updated docs about docs :)