### PR TITLE
log the entire aml job object so people can find the ml studio url

### DIFF
--- a/rats-devtools/src/rats/aml/_app.py
+++ b/rats-devtools/src/rats/aml/_app.py
@@ -525,7 +525,7 @@ class Application(apps.AppContainer, cli.Container, apps.PluginMixin):
             **extra_aml_command_args,
         )
         returned_job = job_ops.create_or_update(job)  # type: ignore[reportUnknownMemberType]
-        logger.info(f"created job: {returned_job.name}")
+        logger.info(f"created job: {returned_job}")
 
         self._request = Request(
             job_name=str(returned_job.name),


### PR DESCRIPTION
if we don't use `--wait` when submitting aml jobs, we don't have any way to know what the url to the job is without opening the aml workspace and finding the details yourself. this change just changes the logs to show the entire aml job object which includes urls to the new job in the studio web ui.

cc. @jzazo